### PR TITLE
docs(epic-5.1): formalize world = manifest concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ A narrow control plane that:
 
 `ABSENT` means the tool/capability is hidden from this world. `DENY` means a visible action was blocked by policy.
 
+## World model
+
+`world_manifest.yaml` is the **static world definition** — the source of truth for what tools
+exist and what policies apply. It is the only policy surface; nothing is configured elsewhere.
+
+`compile_world_manifest()` in `compiler.py` transforms it into a **compiled config** — the
+in-memory runtime state consumed by the policy engine and registry at startup.
+
+| Concept | Role | Mutability |
+|---|---|---|
+| `world_manifest.yaml` | World definition | Static (file on disk) |
+| compiled config | World runtime | Immutable after startup |
+| `world_id` | World identifier | Declared in manifest |
+
+**Agent Hypervisor connection:** safe-mcp-proxy is an Agent Hypervisor bridge — it virtualizes
+tool reality for the agent. The agent sees only the world the manifest defines. Tools absent from
+the manifest do not exist in that world; they cannot be denied because they were never offered.
+
 ## Architecture
 
 ```text

--- a/safe_mcp_proxy/compiler.py
+++ b/safe_mcp_proxy/compiler.py
@@ -18,6 +18,7 @@ def compile_world_manifest(path: str) -> Dict[str, Any]:
     side_effects = raw.get("side_effects", {})
 
     return {
+        "world_id": raw.get("world_id", ""),
         "allowlist": allowed_tools,
         "capability_map": capability_map,
         "taint_rules": taint_rules,


### PR DESCRIPTION
Documents the static/runtime distinction: world_manifest.yaml is the
world definition, compile_world_manifest() produces the compiled config
(world runtime). Adds Agent Hypervisor connection to README and preserves
world_id in the compiled config dict.

Closes #19

https://claude.ai/code/session_01UEhuWHVVuXk54GPjTC7m5h