### PR TITLE
feat(epic-5.2): add multiple world support to build_executor

### DIFF
--- a/safe_mcp_proxy/logs/audit.jsonl
+++ b/safe_mcp_proxy/logs/audit.jsonl
@@ -7,3 +7,5 @@
 {"decision": "DENY", "descriptor_hash": "45dfabdd32b140f2c22605b588d85ff3b54d14f5cc1e848932e048bd9b6db5d0", "rule": "tainted_external_side_effect", "source_channel": "web", "taint": true, "timestamp": "2026-04-22T07:09:18.128580+00:00", "tool": "send_email"}
 {"decision": "DENY", "descriptor_hash": "47e3c1e19919b69dc0bfef5c29477580bf5be91a0b78400d57d1d2e241f2d86e", "rule": "descriptor_drift", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T07:09:18.184181+00:00", "tool": "read_file"}
 {"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T07:09:18.233695+00:00", "tool": "dangerous_exec"}
+{"decision": "ALLOW", "descriptor_hash": "45dfabdd32b140f2c22605b588d85ff3b54d14f5cc1e848932e048bd9b6db5d0", "rule": "default_allow", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T09:59:45.977904+00:00", "tool": "send_email"}
+{"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T09:59:46.041007+00:00", "tool": "send_email"}

--- a/safe_mcp_proxy/main.py
+++ b/safe_mcp_proxy/main.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 from pathlib import Path
+from typing import Optional
 
 import yaml
 
@@ -17,8 +18,14 @@ def _load_simulation_flag(policy_path: Path) -> bool:
     return bool(cfg.get("simulation", {}).get("external_side_effects", False))
 
 
-def build_executor(base_dir: Path) -> Executor:
-    manifest_tables = compile_world_manifest(str(base_dir / "world_manifest.yaml"))
+def build_executor(base_dir: Path, world_id: Optional[str] = None) -> Executor:
+    if world_id is None:
+        manifest_path = base_dir / "world_manifest.yaml"
+    else:
+        manifest_path = base_dir / "worlds" / f"{world_id}.yaml"
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"World manifest not found: {manifest_path}")
+    manifest_tables = compile_world_manifest(str(manifest_path))
     registry = ToolRegistry.with_mock_tools(allowlist=manifest_tables["allowlist"])
     policy_engine = PolicyEngine(
         allowlist=manifest_tables["allowlist"],
@@ -38,10 +45,11 @@ def main() -> None:
     parser.add_argument("--tool", required=True)
     parser.add_argument("--source", default="cli", choices=["cli", "email", "web", "tool_output"])
     parser.add_argument("--payload", default="{}", help="JSON payload")
+    parser.add_argument("--world", default=None, help="World ID (loads worlds/<world_id>.yaml)")
     args = parser.parse_args()
 
     base_dir = Path(__file__).resolve().parents[1]
-    executor = build_executor(base_dir)
+    executor = build_executor(base_dir, world_id=args.world)
     provenance = Provenance.from_source(args.source)
     payload = json.loads(args.payload)
     result = executor.execute(args.tool, payload, provenance)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,8 +1,11 @@
+import shutil
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
 from safe_mcp_proxy.executor import ABSENT_MESSAGE, Executor
+from safe_mcp_proxy.main import build_executor
 from safe_mcp_proxy.policy_engine import PolicyEngine
 from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.registry import ToolRegistry
@@ -44,6 +47,62 @@ class SafeMCPProxyTests(unittest.TestCase):
         result = self.executor.execute("dangerous_exec", {"cmd": "whoami"}, Provenance.from_source("cli"))
         self.assertEqual(result["decision"], "ABSENT")
         self.assertEqual(result["result"]["error"], ABSENT_MESSAGE)
+
+
+class TestMultipleWorlds(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        worlds_dir = self.tmp / "worlds"
+        worlds_dir.mkdir()
+
+        (worlds_dir / "repo_assistant.yaml").write_text(textwrap.dedent("""\
+            world_id: repo_assistant
+            allowed_tools: [read_file, list_repo, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: true}
+              send_email: {allowed: true}
+              dangerous_exec: {allowed: false}
+            taint_rules: []
+            side_effects: {external: restricted}
+        """))
+
+        (worlds_dir / "read_only.yaml").write_text(textwrap.dedent("""\
+            world_id: read_only
+            allowed_tools: [read_file]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: false}
+              send_email: {allowed: false}
+              dangerous_exec: {allowed: false}
+            taint_rules: []
+            side_effects: {external: restricted}
+        """))
+
+        # stub policy.yaml so _load_simulation_flag doesn't fail
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text("simulation:\n  external_side_effects: true\n")
+
+        # stub logs dir
+        logs_dir = self.tmp / "safe_mcp_proxy" / "logs"
+        logs_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_send_email_allow_in_full_world_absent_in_read_only(self):
+        ex_full = build_executor(self.tmp, world_id="repo_assistant")
+        ex_ro = build_executor(self.tmp, world_id="read_only")
+        prov = Provenance.from_source("cli")
+        result_full = ex_full.execute("send_email", {}, prov)
+        result_ro = ex_ro.execute("send_email", {}, prov)
+        self.assertEqual(result_full["decision"], "ALLOW")
+        self.assertEqual(result_ro["decision"], "ABSENT")
+
+    def test_invalid_world_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            build_executor(self.tmp, world_id="nonexistent")
 
 
 if __name__ == "__main__":

--- a/worlds/read_only.yaml
+++ b/worlds/read_only.yaml
@@ -1,0 +1,20 @@
+world_id: "read_only"
+
+allowed_tools:
+  - read_file
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: false
+  send_email:
+    allowed: false
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/worlds/repo_assistant.yaml
+++ b/worlds/repo_assistant.yaml
@@ -1,0 +1,22 @@
+world_id: "repo_assistant"
+
+allowed_tools:
+  - read_file
+  - list_repo
+  - send_email
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: true
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted


### PR DESCRIPTION
Allows switching between isolated policy worlds by passing world_id to
build_executor(). Each world loads its own manifest from worlds/<id>.yaml,
giving different tool allowlists and capability maps from a single agent.

- build_executor(base_dir, world_id=None) — backward-compatible; None loads
  the existing world_manifest.yaml, a string loads worlds/<world_id>.yaml
- Raises FileNotFoundError for unknown world IDs
- Adds --world CLI flag to main.py
- Adds worlds/repo_assistant.yaml (full access) and worlds/read_only.yaml
- Adds TestMultipleWorlds: send_email ALLOW in repo_assistant, ABSENT in read_only

Closes #20

https://claude.ai/code/session_01CetYtQhh6N9cc2PsyHwJ1t