### PR TITLE
feat(epic-5.3): add Executor.replay() for deterministic audit log replay

### DIFF
--- a/safe_mcp_proxy/examples/deterministic_replay.py
+++ b/safe_mcp_proxy/examples/deterministic_replay.py
@@ -1,0 +1,49 @@
+import json
+import tempfile
+from pathlib import Path
+
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.policy_engine import PolicyEngine
+from safe_mcp_proxy.provenance import Provenance
+from safe_mcp_proxy.registry import ToolRegistry
+
+
+if __name__ == "__main__":
+    audit_file = Path(tempfile.gettempdir()) / "replay_demo_audit.jsonl"
+    if audit_file.exists():
+        audit_file.unlink()
+
+    registry = ToolRegistry.with_mock_tools(["read_file", "list_repo", "send_email"])
+    policy = PolicyEngine(
+        allowlist=["read_file", "list_repo", "send_email"],
+        capability_map={"read_file": True, "list_repo": True, "send_email": True},
+    )
+    executor = Executor(registry, policy, str(audit_file), simulate_external=True)
+
+    scenarios = [
+        ("read_file",     {"path": "README.md"}, Provenance.from_source("cli")),
+        ("send_email",    {"to": "x@y.com"},     Provenance.from_source("web")),
+        ("dangerous_exec", {"cmd": "whoami"},    Provenance.from_source("cli")),
+        ("list_repo",     {},                    Provenance.from_source("cli")),
+    ]
+
+    print("Running 100 tool invocations...")
+    for i in range(100):
+        tool_name, payload, prov = scenarios[i % len(scenarios)]
+        executor.execute(tool_name, payload, prov)
+
+    entries = [json.loads(line) for line in audit_file.read_text().splitlines() if line.strip()]
+
+    print(f"\n{'Tool':<20} {'Recorded':<10} {'Replayed':<10} {'Match'}")
+    print("-" * 55)
+
+    matched = 0
+    for entry in entries:
+        result = executor.replay(entry)
+        mark = "OK" if result["matches"] else "FAIL"
+        print(f"{entry['tool']:<20} {result['recorded_decision']:<10} {result['replayed_decision']:<10} {mark}")
+        if result["matches"]:
+            matched += 1
+
+    pct = 100 * matched // len(entries)
+    print(f"\nResult: {matched}/{len(entries)} entries matched ({pct}%)")

--- a/safe_mcp_proxy/executor.py
+++ b/safe_mcp_proxy/executor.py
@@ -60,6 +60,32 @@ class Executor:
         )
         return {"decision": policy.decision, "rule": policy.rule_hit, "result": response}
 
+    def replay(self, audit_entry: Dict[str, Any]) -> Dict[str, Any]:
+        tool_name = audit_entry["tool"]
+        tainted = audit_entry["taint"]
+
+        tool = self.registry.get_tool(tool_name)
+        capability = tool.capability if tool else tool_name
+        side_effect_type = tool.side_effect_type if tool else "unknown"
+        descriptor_hash_ok = descriptor_hash_valid(tool.schema, tool.descriptor_hash) if tool else True
+
+        policy = self.policy_engine.decide(
+            tool_name=tool_name,
+            capability=capability,
+            taint=tainted,
+            side_effect_type=side_effect_type,
+            descriptor_hash_valid=descriptor_hash_ok,
+        )
+
+        matches = policy.decision == audit_entry["decision"] and policy.rule_hit == audit_entry["rule"]
+        return {
+            "recorded_decision": audit_entry["decision"],
+            "recorded_rule": audit_entry["rule"],
+            "replayed_decision": policy.decision,
+            "replayed_rule": policy.rule_hit,
+            "matches": matches,
+        }
+
     def _audit(
         self,
         tool: str,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import tempfile
 import textwrap
@@ -47,6 +48,46 @@ class SafeMCPProxyTests(unittest.TestCase):
         result = self.executor.execute("dangerous_exec", {"cmd": "whoami"}, Provenance.from_source("cli"))
         self.assertEqual(result["decision"], "ABSENT")
         self.assertEqual(result["result"]["error"], ABSENT_MESSAGE)
+
+    def _last_audit_entry(self):
+        with self.audit_file.open() as f:
+            return json.loads(f.readlines()[-1])
+
+    def test_replay_allow(self):
+        self.executor.execute("read_file", {"path": "README.md"}, Provenance.from_source("cli"))
+        result = self.executor.replay(self._last_audit_entry())
+        self.assertTrue(result["matches"])
+        self.assertEqual(result["replayed_decision"], "ALLOW")
+
+    def test_replay_deny_tainted(self):
+        self.executor.execute("send_email", {"to": "x@y.com"}, Provenance.from_source("web"))
+        result = self.executor.replay(self._last_audit_entry())
+        self.assertTrue(result["matches"])
+        self.assertEqual(result["replayed_decision"], "DENY")
+
+    def test_replay_absent(self):
+        self.executor.execute("dangerous_exec", {"cmd": "whoami"}, Provenance.from_source("cli"))
+        result = self.executor.replay(self._last_audit_entry())
+        self.assertTrue(result["matches"])
+        self.assertEqual(result["replayed_decision"], "ABSENT")
+
+    def test_replay_100_entries(self):
+        scenarios = [
+            ("read_file", {"path": "README.md"}, Provenance.from_source("cli")),
+            ("send_email", {"to": "x@y.com"}, Provenance.from_source("web")),
+            ("dangerous_exec", {"cmd": "whoami"}, Provenance.from_source("cli")),
+            ("list_repo", {}, Provenance.from_source("cli")),
+        ]
+        for i in range(100):
+            tool_name, payload, prov = scenarios[i % len(scenarios)]
+            self.executor.execute(tool_name, payload, prov)
+
+        entries = [json.loads(line) for line in self.audit_file.read_text().splitlines() if line.strip()]
+        self.assertGreaterEqual(len(entries), 100)
+
+        results = [self.executor.replay(e) for e in entries]
+        matches = sum(1 for r in results if r["matches"])
+        self.assertEqual(matches, len(entries), f"Only {matches}/{len(entries)} entries matched")
 
 
 class TestMultipleWorlds(unittest.TestCase):


### PR DESCRIPTION
Proves policy determinism: given the same registry state and provenance,
re-evaluating any audit entry produces 100% matching decisions.

https://claude.ai/code/session_01LgaFpdJvsjJSeTRQ9ng5AU