### PR TITLE
docs: reference Agent Hypervisor as a real repo, not just a concept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**safe-mcp-proxy** is a minimal, deterministic control plane for the Model Context Protocol (MCP) that constrains tool exposure and execution to mitigate runtime supply-chain risks. It is a concrete MCP implementation of the [Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) model — a real security framework from the same author, not merely a concept.
+**safe-mcp-proxy** is a minimal, deterministic control plane for the Model Context Protocol (MCP) that constrains tool exposure and execution to mitigate runtime supply-chain risks. It is a productized MCP spinoff of [Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) — the author's experimental research playground where all ideas about agent security are explored (whitepapers, ADRs, benchmarks, full reference implementation). When working on an approach not fully specified here, check agent-hypervisor first for prior art, design decisions, and implementation patterns.
 
 Core design principle: *"Some actions are denied. Others do not exist."*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**safe-mcp-proxy** is a minimal, deterministic control plane for the Model Context Protocol (MCP) that constrains tool exposure and execution to mitigate runtime supply-chain risks.
+**safe-mcp-proxy** is a minimal, deterministic control plane for the Model Context Protocol (MCP) that constrains tool exposure and execution to mitigate runtime supply-chain risks. It is a concrete MCP implementation of the [Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) model — a real security framework from the same author, not merely a concept.
 
 Core design principle: *"Some actions are denied. Others do not exist."*
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are two distinct outcomes when a tool call is blocked:
 
 This distinction matters. An agent that cannot see a tool cannot be manipulated into calling it. ABSENT is stronger than DENY.
 
-**Agent Hypervisor connection:** safe-mcp-proxy is an Agent Hypervisor bridge — it virtualizes tool reality for the agent. The agent sees only the world the manifest defines. Tools absent from the manifest do not exist in that world; they cannot be denied because they were never offered.
+**[Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) bridge:** safe-mcp-proxy is a concrete MCP implementation of the Agent Hypervisor model — a real security framework from the same author. Agent Hypervisor defines a four-layer architecture (execution isolation → base ontology → dynamic ontology → execution governance); safe-mcp-proxy implements Layers 1–3 for the MCP context. The agent sees only the world the manifest defines. Tools absent from the manifest do not exist in that world; they cannot be denied because they were never offered.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ There are two distinct outcomes when a tool call is blocked:
 
 This distinction matters. An agent that cannot see a tool cannot be manipulated into calling it. ABSENT is stronger than DENY.
 
-**[Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) bridge:** safe-mcp-proxy is a concrete MCP implementation of the Agent Hypervisor model — a real security framework from the same author. Agent Hypervisor defines a four-layer architecture (execution isolation → base ontology → dynamic ontology → execution governance); safe-mcp-proxy implements Layers 1–3 for the MCP context. The agent sees only the world the manifest defines. Tools absent from the manifest do not exist in that world; they cannot be denied because they were never offered.
+**[Agent Hypervisor](https://github.com/sv-pro/agent-hypervisor) spinoff:** safe-mcp-proxy is a productized MCP spinoff of Agent Hypervisor — the author's experimental research playground that explores the full four-layer agent security architecture (execution isolation → base ontology → dynamic ontology → execution governance). safe-mcp-proxy distills Layers 1–3 into a minimal, production-grade MCP control plane. The agent-hypervisor repo is the upstream reference: consult it for whitepapers, ADRs, deeper design decisions, and implementation patterns not covered here. The agent sees only the world the manifest defines. Tools absent from the manifest do not exist in that world; they cannot be denied because they were never offered.
 
 ## Architecture
 


### PR DESCRIPTION
Add explicit link to https://github.com/sv-pro/agent-hypervisor in both
README.md and CLAUDE.md. Clarify that safe-mcp-proxy implements Layers 1–3
of the Agent Hypervisor four-layer architecture for the MCP context.

https://claude.ai/code/session_014AhrUhgDtqaNBhPDiVYSjX