### PR TITLE
Load per-world manifests from safe_mcp_proxy/config/worlds with legacy fallback and add world fixtures/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ side_effects:
 | compiled config | World runtime | Immutable after startup |
 | `world_id` | World identifier | Declared in manifest |
 
-Multiple worlds are supported via the `worlds/` directory. Pass `--world <world_id>` to load `worlds/<world_id>.yaml` instead of the default manifest.
+Multiple worlds are supported via `safe_mcp_proxy/config/worlds/` (with legacy fallback to `worlds/`). Pass `--world <world_id>` to load `safe_mcp_proxy/config/worlds/<world_id>.yaml` instead of the default manifest.
 
 ## Quick start
 

--- a/safe_mcp_proxy/config/worlds/world_a.yaml
+++ b/safe_mcp_proxy/config/worlds/world_a.yaml
@@ -1,0 +1,22 @@
+world_id: "world_a"
+
+allowed_tools:
+  - read_file
+  - list_repo
+  - send_email
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: true
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/safe_mcp_proxy/config/worlds/world_b.yaml
+++ b/safe_mcp_proxy/config/worlds/world_b.yaml
@@ -1,0 +1,20 @@
+world_id: "world_b"
+
+allowed_tools:
+  - read_file
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: false
+  send_email:
+    allowed: false
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/safe_mcp_proxy/config/worlds/world_c.yaml
+++ b/safe_mcp_proxy/config/worlds/world_c.yaml
@@ -1,0 +1,22 @@
+world_id: "world_c"
+
+allowed_tools:
+  - read_file
+  - list_repo
+  - send_email
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: false
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/safe_mcp_proxy/main.py
+++ b/safe_mcp_proxy/main.py
@@ -18,13 +18,24 @@ def _load_simulation_flag(policy_path: Path) -> bool:
     return bool(cfg.get("simulation", {}).get("external_side_effects", False))
 
 
-def build_executor(base_dir: Path, world_id: Optional[str] = None) -> Executor:
+def _resolve_manifest_path(base_dir: Path, world_id: Optional[str]) -> Path:
     if world_id is None:
-        manifest_path = base_dir / "world_manifest.yaml"
-    else:
-        manifest_path = base_dir / "worlds" / f"{world_id}.yaml"
-        if not manifest_path.exists():
-            raise FileNotFoundError(f"World manifest not found: {manifest_path}")
+        return base_dir / "world_manifest.yaml"
+
+    candidates = [
+        base_dir / "safe_mcp_proxy" / "config" / "worlds" / f"{world_id}.yaml",
+        base_dir / "worlds" / f"{world_id}.yaml",
+    ]
+    for manifest_path in candidates:
+        if manifest_path.exists():
+            return manifest_path
+
+    searched = ", ".join(str(path) for path in candidates)
+    raise FileNotFoundError(f"World manifest not found for world_id={world_id!r}. Searched: {searched}")
+
+
+def build_executor(base_dir: Path, world_id: Optional[str] = None) -> Executor:
+    manifest_path = _resolve_manifest_path(base_dir, world_id)
     manifest_tables = compile_world_manifest(str(manifest_path))
     registry = ToolRegistry.with_mock_tools(allowlist=manifest_tables["allowlist"])
     policy_engine = PolicyEngine(
@@ -45,7 +56,7 @@ def main() -> None:
     parser.add_argument("--tool", required=True)
     parser.add_argument("--source", default="cli", choices=["cli", "email", "web", "tool_output"])
     parser.add_argument("--payload", default="{}", help="JSON payload")
-    parser.add_argument("--world", default=None, help="World ID (loads worlds/<world_id>.yaml)")
+    parser.add_argument("--world", default=None, help="World ID (loads safe_mcp_proxy/config/worlds/<world_id>.yaml, falls back to worlds/<world_id>.yaml)")
     args = parser.parse_args()
 
     base_dir = Path(__file__).resolve().parents[1]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -103,11 +103,12 @@ class SafeMCPProxyTests(unittest.TestCase):
 class TestMultipleWorlds(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
-        worlds_dir = self.tmp / "worlds"
-        worlds_dir.mkdir()
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        worlds_dir = config_dir / "worlds"
+        worlds_dir.mkdir(parents=True)
 
-        (worlds_dir / "repo_assistant.yaml").write_text(textwrap.dedent("""\
-            world_id: repo_assistant
+        (worlds_dir / "world_a.yaml").write_text(textwrap.dedent("""\
+            world_id: world_a
             allowed_tools: [read_file, list_repo, send_email]
             capabilities:
               read_file: {allowed: true}
@@ -118,8 +119,8 @@ class TestMultipleWorlds(unittest.TestCase):
             side_effects: {external: restricted}
         """))
 
-        (worlds_dir / "read_only.yaml").write_text(textwrap.dedent("""\
-            world_id: read_only
+        (worlds_dir / "world_b.yaml").write_text(textwrap.dedent("""\
+            world_id: world_b
             allowed_tools: [read_file]
             capabilities:
               read_file: {allowed: true}
@@ -130,9 +131,19 @@ class TestMultipleWorlds(unittest.TestCase):
             side_effects: {external: restricted}
         """))
 
+        (worlds_dir / "world_c.yaml").write_text(textwrap.dedent("""\
+            world_id: world_c
+            allowed_tools: [read_file, list_repo, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: true}
+              send_email: {allowed: false}
+              dangerous_exec: {allowed: false}
+            taint_rules: []
+            side_effects: {external: restricted}
+        """))
+
         # stub policy.yaml so _load_simulation_flag doesn't fail
-        config_dir = self.tmp / "safe_mcp_proxy" / "config"
-        config_dir.mkdir(parents=True)
         (config_dir / "policy.yaml").write_text("simulation:\n  external_side_effects: true\n")
 
         # stub logs dir
@@ -142,14 +153,20 @@ class TestMultipleWorlds(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_send_email_allow_in_full_world_absent_in_read_only(self):
-        ex_full = build_executor(self.tmp, world_id="repo_assistant")
-        ex_ro = build_executor(self.tmp, world_id="read_only")
+    def test_same_input_yields_different_decisions_across_worlds(self):
+        ex_world_a = build_executor(self.tmp, world_id="world_a")
+        ex_world_b = build_executor(self.tmp, world_id="world_b")
+        ex_world_c = build_executor(self.tmp, world_id="world_c")
         prov = Provenance.from_source("cli")
-        result_full = ex_full.execute("send_email", {}, prov)
-        result_ro = ex_ro.execute("send_email", {}, prov)
-        self.assertEqual(result_full["decision"], "ALLOW")
-        self.assertEqual(result_ro["decision"], "ABSENT")
+
+        result_a = ex_world_a.execute("send_email", {}, prov)
+        result_b = ex_world_b.execute("send_email", {}, prov)
+        result_c = ex_world_c.execute("send_email", {}, prov)
+
+        self.assertEqual(result_a["decision"], "ALLOW")
+        self.assertEqual(result_b["decision"], "ABSENT")
+        self.assertEqual(result_c["decision"], "ABSENT")
+        self.assertEqual(result_c["rule"], "capability_not_allowed")
 
     def test_invalid_world_raises(self):
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
### Motivation
- Centralize runtime world manifests under `safe_mcp_proxy/config/worlds/` while preserving the legacy `worlds/` fallback to allow multiple environment configurations. 
- Provide packaged example world definitions and automated tests to validate that the same input can yield different policy decisions across worlds. 

### Description
- Update README to document the new world manifest lookup path and fallback behavior. 
- Add three example world manifests under `safe_mcp_proxy/config/worlds/`: `world_a.yaml`, `world_b.yaml`, and `world_c.yaml`. 
- Refactor `safe_mcp_proxy/main.py` to introduce `_resolve_manifest_path` which searches `safe_mcp_proxy/config/worlds/<world_id>.yaml` then `worlds/<world_id>.yaml`, and update `build_executor` and the CLI `--world` help text accordingly. 
- Update `tests/test_proxy.py` to create the new config directory layout, write world fixtures and a `policy.yaml` stub, and add a test (`test_same_input_yields_different_decisions_across_worlds`) asserting decisions vary by world. 

### Testing
- Ran the unit tests in `tests/test_proxy.py` via `python -m unittest` and the modified tests completed successfully. 
- Exercised the new manifest resolution paths in the updated tests to confirm `FileNotFoundError` is raised for unknown worlds and that decisions match expected values across `world_a`, `world_b`, and `world_c`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e4631e3c832586d457754e324ee5)