### PR TITLE
feat(DS1.1): add minimal trace viewer UI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
 
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
@@ -52,6 +53,12 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    _ui_path = Path(__file__).resolve().parent.parent / "ui" / "index.html"
+
+    @app.get("/", response_class=HTMLResponse)
+    async def serve_ui():
+        return HTMLResponse(content=_ui_path.read_text(encoding="utf-8"))
 
     @app.get("/traces")
     async def list_traces(limit: int = Query(default=100, ge=1, le=1000)) -> dict:

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>safe-mcp-proxy</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: ui-monospace, "Cascadia Code", "Fira Code", monospace;
+      font-size: 13px;
+      background: #0f1117;
+      color: #c9d1d9;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      padding: 10px 16px;
+      background: #161b22;
+      border-bottom: 1px solid #30363d;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    header h1 {
+      font-size: 13px;
+      font-weight: 600;
+      color: #e6edf3;
+      letter-spacing: 0.03em;
+    }
+
+    header .subtitle {
+      color: #6e7681;
+      font-size: 11px;
+    }
+
+    #status {
+      margin-left: auto;
+      font-size: 11px;
+      color: #6e7681;
+    }
+
+    #status.live::before {
+      content: "● ";
+      color: #3fb950;
+    }
+
+    #status.error::before {
+      content: "● ";
+      color: #f85149;
+    }
+
+    main {
+      display: flex;
+      flex: 1;
+      overflow: hidden;
+    }
+
+    /* ── Left panel ─────────────────────────────────────── */
+    #list-panel {
+      width: 38%;
+      min-width: 300px;
+      border-right: 1px solid #30363d;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    #list-panel h2 {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6e7681;
+      padding: 8px 12px;
+      border-bottom: 1px solid #21262d;
+      flex-shrink: 0;
+    }
+
+    #trace-table-wrap {
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    thead th {
+      position: sticky;
+      top: 0;
+      background: #161b22;
+      color: #6e7681;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 5px 10px;
+      text-align: left;
+      border-bottom: 1px solid #21262d;
+      z-index: 1;
+    }
+
+    tbody tr {
+      cursor: pointer;
+      border-bottom: 1px solid #161b22;
+      transition: background 0.08s;
+    }
+
+    tbody tr:hover { background: #1c2128; }
+    tbody tr.selected { background: #1f2d3d; }
+
+    tbody td {
+      padding: 5px 10px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 0;
+    }
+
+    td.col-time  { width: 70px; color: #6e7681; }
+    td.col-tool  { width: 40%; color: #e6edf3; }
+    td.col-dec   { width: 80px; }
+    td.col-src   { width: 30%; color: #8b949e; }
+
+    /* ── Decision badges ────────────────────────────────── */
+    .badge {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      line-height: 16px;
+    }
+    .badge-ALLOW    { background: #1a3a5c; color: #58a6ff; }
+    .badge-DENY     { background: #3d2200; color: #e3b341; }
+    .badge-ABSENT   { background: #21262d; color: #8b949e; }
+    .badge-SIMULATE { background: #0d2d2d; color: #39d0d0; }
+
+    /* ── Right panel ────────────────────────────────────── */
+    #detail-panel {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    }
+
+    #detail-panel .placeholder {
+      color: #6e7681;
+      margin-top: 40px;
+      text-align: center;
+    }
+
+    .detail-section {
+      margin-bottom: 20px;
+    }
+
+    .detail-section h3 {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6e7681;
+      margin-bottom: 8px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid #21262d;
+    }
+
+    .field-grid {
+      display: grid;
+      grid-template-columns: 140px 1fr;
+      gap: 4px 12px;
+    }
+
+    .field-key {
+      color: #6e7681;
+      padding: 2px 0;
+    }
+
+    .field-val {
+      color: #e6edf3;
+      word-break: break-all;
+      padding: 2px 0;
+    }
+
+    .field-val.mono {
+      font-size: 11px;
+      color: #8b949e;
+    }
+
+    /* ── Pipeline diagram ───────────────────────────────── */
+    .pipeline {
+      display: flex;
+      align-items: center;
+      gap: 0;
+      flex-wrap: wrap;
+      margin-top: 6px;
+    }
+
+    .pipe-step {
+      display: flex;
+      align-items: center;
+    }
+
+    .pipe-label {
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 11px;
+      background: #21262d;
+      color: #6e7681;
+      white-space: nowrap;
+    }
+
+    .pipe-label.active {
+      background: #1a3a5c;
+      color: #58a6ff;
+      font-weight: 700;
+    }
+
+    .pipe-label.active.deny  { background: #3d2200; color: #e3b341; }
+    .pipe-label.active.absent { background: #21262d; color: #c9d1d9; }
+
+    .pipe-arrow {
+      color: #30363d;
+      margin: 0 4px;
+      font-size: 14px;
+    }
+
+    #empty-msg { color: #6e7681; padding: 20px 10px; text-align: center; font-size: 12px; }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>safe-mcp-proxy</h1>
+  <span class="subtitle">trace viewer</span>
+  <span id="status">connecting…</span>
+</header>
+
+<main>
+  <section id="list-panel" aria-label="Trace list">
+    <h2>Traces</h2>
+    <div id="trace-table-wrap">
+      <table id="trace-table" aria-label="Audit traces">
+        <thead>
+          <tr>
+            <th class="col-time">Time</th>
+            <th class="col-tool">Tool</th>
+            <th class="col-dec">Decision</th>
+            <th class="col-src">Channel</th>
+          </tr>
+        </thead>
+        <tbody id="trace-body">
+          <tr><td colspan="4" id="empty-msg">Loading…</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section id="detail-panel" aria-label="Trace detail">
+    <p class="placeholder" id="detail-placeholder">Select a trace to see details.</p>
+    <div id="detail-content" style="display:none"></div>
+  </section>
+</main>
+
+<script>
+  const POLL_MS = 5000;
+
+  const statusEl  = document.getElementById('status');
+  const tbody     = document.getElementById('trace-body');
+  const detailPH  = document.getElementById('detail-placeholder');
+  const detailDiv = document.getElementById('detail-content');
+
+  let traces = [];
+  let selectedId = null;
+
+  // ── Decision → pipeline stage ────────────────────────────
+  const PIPELINE_STAGES = [
+    { label: 'Provenance', rules: [] },
+    { label: 'Registry',   rules: ['tool_not_allowlisted', 'capability_not_allowed'] },
+    { label: 'Policy',     rules: ['descriptor_drift', 'tainted_external_side_effect'] },
+    { label: 'Execution',  rules: ['default_allow'] },
+  ];
+
+  function activeStageIndex(rule) {
+    for (let i = 0; i < PIPELINE_STAGES.length; i++) {
+      if (PIPELINE_STAGES[i].rules.includes(rule)) return i;
+    }
+    return PIPELINE_STAGES.length - 1; // default: Execution
+  }
+
+  // ── Formatting ────────────────────────────────────────────
+  function fmtTime(ts) {
+    try {
+      return new Date(ts).toLocaleTimeString('en-GB', { hour12: false });
+    } catch { return ts; }
+  }
+
+  function badge(decision) {
+    const cls = 'badge badge-' + (decision || 'ABSENT');
+    return `<span class="${cls}">${decision || '?'}</span>`;
+  }
+
+  // ── Render list ───────────────────────────────────────────
+  function renderList() {
+    if (!traces.length) {
+      tbody.innerHTML = '<tr><td colspan="4" id="empty-msg">No traces yet.</td></tr>';
+      return;
+    }
+    // Show newest first
+    const rows = [...traces].reverse().map(t => {
+      const sel = t.id === selectedId ? ' class="selected"' : '';
+      return `<tr data-id="${t.id}"${sel}>
+        <td class="col-time">${fmtTime(t.timestamp)}</td>
+        <td class="col-tool" title="${t.tool_requested}">${t.tool_requested}</td>
+        <td class="col-dec">${badge(t.decision)}</td>
+        <td class="col-src">${t.source_channel}</td>
+      </tr>`;
+    });
+    tbody.innerHTML = rows.join('');
+    tbody.querySelectorAll('tr[data-id]').forEach(row => {
+      row.addEventListener('click', () => selectTrace(Number(row.dataset.id)));
+    });
+  }
+
+  // ── Render detail ─────────────────────────────────────────
+  function renderDetail(trace) {
+    const stageIdx = activeStageIndex(trace.rule_hit);
+    const dec = trace.decision;
+    const isDeny   = dec === 'DENY';
+    const isAbsent = dec === 'ABSENT';
+
+    const pipelineHtml = PIPELINE_STAGES.map((s, i) => {
+      let cls = 'pipe-label';
+      if (i === stageIdx) {
+        cls += ' active';
+        if (isDeny)   cls += ' deny';
+        if (isAbsent) cls += ' absent';
+      }
+      const arrow = i < PIPELINE_STAGES.length - 1
+        ? '<span class="pipe-arrow">›</span>' : '';
+      return `<span class="pipe-step"><span class="${cls}">${s.label}</span></span>${arrow}`;
+    }).join('');
+
+    const hashDisplay = trace.descriptor_hash
+      ? `<span class="mono">${trace.descriptor_hash.slice(0, 16)}…</span>`
+      : '<span style="color:#6e7681">—</span>';
+
+    detailDiv.innerHTML = `
+      <div class="detail-section">
+        <h3>Decision</h3>
+        <div class="field-grid">
+          <span class="field-key">outcome</span>
+          <span class="field-val">${badge(trace.decision)}</span>
+          <span class="field-key">rule</span>
+          <span class="field-val">${trace.rule_hit}</span>
+        </div>
+      </div>
+
+      <div class="detail-section">
+        <h3>Pipeline</h3>
+        <div class="pipeline">${pipelineHtml}</div>
+      </div>
+
+      <div class="detail-section">
+        <h3>Request</h3>
+        <div class="field-grid">
+          <span class="field-key">tool</span>
+          <span class="field-val">${trace.tool_requested}</span>
+          <span class="field-key">source_channel</span>
+          <span class="field-val">${trace.source_channel}</span>
+          <span class="field-key">taint</span>
+          <span class="field-val">${trace.taint ? '⚠ tainted' : 'clean'}</span>
+        </div>
+      </div>
+
+      <div class="detail-section">
+        <h3>Metadata</h3>
+        <div class="field-grid">
+          <span class="field-key">id</span>
+          <span class="field-val">${trace.id}</span>
+          <span class="field-key">timestamp</span>
+          <span class="field-val">${trace.timestamp}</span>
+          <span class="field-key">descriptor_hash</span>
+          <span class="field-val">${hashDisplay}</span>
+          <span class="field-key">schema_version</span>
+          <span class="field-val">${trace.schema_version}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Selection ─────────────────────────────────────────────
+  function selectTrace(id) {
+    selectedId = id;
+    const trace = traces.find(t => t.id === id);
+    if (!trace) return;
+
+    tbody.querySelectorAll('tr[data-id]').forEach(row => {
+      row.classList.toggle('selected', Number(row.dataset.id) === id);
+    });
+
+    detailPH.style.display = 'none';
+    detailDiv.style.display = 'block';
+    renderDetail(trace);
+  }
+
+  // ── Fetch & poll ──────────────────────────────────────────
+  async function fetchTraces() {
+    try {
+      const res = await fetch('/traces?limit=200');
+      if (!res.ok) throw new Error(res.status);
+      const data = await res.json();
+      traces = data.traces || [];
+      renderList();
+      // Keep detail in sync if selected trace updated
+      if (selectedId !== null) {
+        const current = traces.find(t => t.id === selectedId);
+        if (current) renderDetail(current);
+      }
+      statusEl.textContent = `live · ${traces.length} trace${traces.length !== 1 ? 's' : ''}`;
+      statusEl.className = 'live';
+    } catch (err) {
+      statusEl.textContent = `error: ${err.message}`;
+      statusEl.className = 'error';
+    }
+  }
+
+  fetchTraces();
+  setInterval(fetchTraces, POLL_MS);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Single-page Vanilla JS trace viewer served at GET /. Left panel shows
a live-polling trace list (time, tool, decision badge, source_channel);
right panel shows full detail + pipeline stage highlight on click.

Closes #59

https://claude.ai/code/session_01HaSaP5FKj6X8ePzEX9U2Rd