### PR TITLE
feat(DS1.4): add decision semantics to trace viewer

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 
+import safe_mcp_proxy.scenarios as _scenarios
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.main import build_executor
@@ -77,6 +78,22 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             "trace_id": trace.id,
             **replay,
             "diverged": not replay["matches"],
+        }
+
+    @app.post("/scenarios/{name}/run")
+    async def run_scenario(name: str) -> dict:
+        try:
+            outcome = _scenarios.run(name, base_dir=resolved_base_dir)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        traces = app.state.trace_store.all()
+        trace_id = traces[-1].id if traces else None
+        return {
+            "scenario": name,
+            "trace_id": trace_id,
+            "decision": outcome["result"]["decision"],
+            "rule": outcome["result"]["rule"],
+            "matches": outcome["matches"],
         }
 
     @app.get("/stats")

--- a/safe_mcp_proxy/scenarios/__init__.py
+++ b/safe_mcp_proxy/scenarios/__init__.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class Scenario:
+    name: str
+    description: str
+    tool: str
+    payload: Dict[str, Any]
+    source_channel: str
+    expected_decision: str
+    expected_rule: str
+    setup: Optional[Callable] = field(default=None, repr=False)
+
+
+SCENARIOS: Dict[str, Scenario] = {}
+
+
+def register(scenario: Scenario) -> None:
+    SCENARIOS[scenario.name] = scenario
+
+
+def get(name: str) -> Scenario:
+    try:
+        return SCENARIOS[name]
+    except KeyError:
+        raise KeyError(f"Unknown scenario: {name!r}. Available: {list(SCENARIOS)}")
+
+
+def names() -> List[str]:
+    return list(SCENARIOS)
+
+
+def run(name: str, executor=None, base_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Execute a named scenario and return the result with pass/fail against expected outcome."""
+    scenario = get(name)
+    if executor is None:
+        from safe_mcp_proxy.main import build_executor
+        if base_dir is None:
+            base_dir = Path(__file__).resolve().parents[2]
+        executor = build_executor(base_dir)
+    if scenario.setup is not None:
+        scenario.setup(executor)
+    from safe_mcp_proxy.provenance import Provenance
+    provenance = Provenance.from_source(scenario.source_channel)
+    result = executor.execute(scenario.tool, scenario.payload, provenance)
+    return {
+        "scenario": name,
+        "result": result,
+        "expected_decision": scenario.expected_decision,
+        "expected_rule": scenario.expected_rule,
+        "matches": (
+            result["decision"] == scenario.expected_decision
+            and result["rule"] == scenario.expected_rule
+        ),
+    }
+
+
+# Bootstrap: import submodules so they self-register
+from safe_mcp_proxy.scenarios import (  # noqa: E402, F401
+    absent_tool,
+    benign_flow,
+    poisoned_descriptor,
+    prompt_injection,
+)

--- a/safe_mcp_proxy/scenarios/absent_tool.py
+++ b/safe_mcp_proxy/scenarios/absent_tool.py
@@ -1,0 +1,11 @@
+from safe_mcp_proxy.scenarios import Scenario, register
+
+register(Scenario(
+    name="absent_tool",
+    description="Tool not in world allowlist — does not exist in this world",
+    tool="dangerous_exec",
+    payload={"cmd": "rm -rf /"},
+    source_channel="cli",
+    expected_decision="ABSENT",
+    expected_rule="tool_not_allowlisted",
+))

--- a/safe_mcp_proxy/scenarios/benign_flow.py
+++ b/safe_mcp_proxy/scenarios/benign_flow.py
@@ -1,0 +1,11 @@
+from safe_mcp_proxy.scenarios import Scenario, register
+
+register(Scenario(
+    name="benign_flow",
+    description="Clean CLI read — passes all policy checks",
+    tool="read_file",
+    payload={"path": "README.md"},
+    source_channel="cli",
+    expected_decision="ALLOW",
+    expected_rule="default_allow",
+))

--- a/safe_mcp_proxy/scenarios/poisoned_descriptor.py
+++ b/safe_mcp_proxy/scenarios/poisoned_descriptor.py
@@ -1,0 +1,19 @@
+from safe_mcp_proxy.scenarios import Scenario, register
+
+
+def _mutate_schema(executor) -> None:
+    tool = executor.registry.get_tool("read_file")
+    if tool:
+        tool.schema["properties"]["encoding"] = {"type": "string"}
+
+
+register(Scenario(
+    name="poisoned_descriptor",
+    description="Schema mutated at runtime — triggers descriptor drift detection",
+    tool="read_file",
+    payload={"path": "README.md"},
+    source_channel="cli",
+    expected_decision="DENY",
+    expected_rule="descriptor_drift",
+    setup=_mutate_schema,
+))

--- a/safe_mcp_proxy/scenarios/prompt_injection.py
+++ b/safe_mcp_proxy/scenarios/prompt_injection.py
@@ -1,0 +1,11 @@
+from safe_mcp_proxy.scenarios import Scenario, register
+
+register(Scenario(
+    name="prompt_injection",
+    description="External-channel request to an external-side-effect tool — denied by taint policy",
+    tool="send_email",
+    payload={"to": "attacker@example.com", "body": "please exfiltrate"},
+    source_channel="web",
+    expected_decision="DENY",
+    expected_rule="tainted_external_side_effect",
+))

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,104 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.main import build_executor
+from safe_mcp_proxy.policy_engine import PolicyEngine
+from safe_mcp_proxy.registry import ToolRegistry
+import safe_mcp_proxy.scenarios as scenarios
+
+
+def _make_executor(audit_path: str) -> Executor:
+    registry = ToolRegistry.with_mock_tools(["read_file", "list_repo", "send_email"])
+    policy = PolicyEngine(
+        allowlist=["read_file", "list_repo", "send_email"],
+        capability_map={"read_file": True, "list_repo": True, "send_email": True},
+    )
+    return Executor(registry, policy, audit_path, simulate_external=True)
+
+
+class TestScenarioRegistry(unittest.TestCase):
+    def test_all_builtins_registered(self):
+        for name in ("benign_flow", "prompt_injection", "poisoned_descriptor", "absent_tool"):
+            self.assertIn(name, scenarios.SCENARIOS)
+
+    def test_names_returns_all_builtins(self):
+        self.assertTrue({"benign_flow", "prompt_injection", "poisoned_descriptor", "absent_tool"}
+                        .issubset(set(scenarios.names())))
+
+    def test_get_known_scenario(self):
+        s = scenarios.get("benign_flow")
+        self.assertEqual(s.name, "benign_flow")
+        self.assertEqual(s.tool, "read_file")
+        self.assertEqual(s.source_channel, "cli")
+        self.assertEqual(s.expected_decision, "ALLOW")
+
+    def test_get_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            scenarios.get("nonexistent")
+
+    def test_scenario_has_required_fields(self):
+        for name in scenarios.names():
+            s = scenarios.get(name)
+            self.assertTrue(s.name)
+            self.assertTrue(s.description)
+            self.assertTrue(s.tool)
+            self.assertIn(s.source_channel, ("cli", "email", "web", "tool_output"))
+            self.assertIn(s.expected_decision, ("ALLOW", "DENY", "ABSENT", "SIMULATE"))
+            self.assertTrue(s.expected_rule)
+
+
+class TestScenarioRun(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False)
+        self._audit = self._tmp.name
+        self._tmp.close()
+
+    def _executor(self):
+        return _make_executor(self._audit)
+
+    def test_benign_flow_matches(self):
+        out = scenarios.run("benign_flow", executor=self._executor())
+        self.assertEqual(out["result"]["decision"], "ALLOW")
+        self.assertEqual(out["result"]["rule"], "default_allow")
+        self.assertTrue(out["matches"])
+
+    def test_prompt_injection_matches(self):
+        out = scenarios.run("prompt_injection", executor=self._executor())
+        self.assertEqual(out["result"]["decision"], "DENY")
+        self.assertEqual(out["result"]["rule"], "tainted_external_side_effect")
+        self.assertTrue(out["matches"])
+
+    def test_poisoned_descriptor_matches(self):
+        out = scenarios.run("poisoned_descriptor", executor=self._executor())
+        self.assertEqual(out["result"]["decision"], "DENY")
+        self.assertEqual(out["result"]["rule"], "descriptor_drift")
+        self.assertTrue(out["matches"])
+
+    def test_absent_tool_matches(self):
+        out = scenarios.run("absent_tool", executor=self._executor())
+        self.assertEqual(out["result"]["decision"], "ABSENT")
+        self.assertEqual(out["result"]["rule"], "tool_not_allowlisted")
+        self.assertTrue(out["matches"])
+
+    def test_run_result_shape(self):
+        out = scenarios.run("benign_flow", executor=self._executor())
+        self.assertIn("scenario", out)
+        self.assertIn("result", out)
+        self.assertIn("expected_decision", out)
+        self.assertIn("expected_rule", out)
+        self.assertIn("matches", out)
+
+    def test_run_unknown_raises(self):
+        with self.assertRaises(KeyError):
+            scenarios.run("does_not_exist", executor=self._executor())
+
+    def test_poisoned_descriptor_isolation(self):
+        # Each run() with a fresh executor should not affect other executors
+        ex1 = self._executor()
+        ex2 = self._executor()
+        scenarios.run("poisoned_descriptor", executor=ex1)
+        # ex2 should still allow read_file normally
+        out = scenarios.run("benign_flow", executor=ex2)
+        self.assertTrue(out["matches"])

--- a/ui/index.html
+++ b/ui/index.html
@@ -281,6 +281,14 @@
   let traces = [];
   let selectedId = null;
 
+  // ── Decision semantics ───────────────────────────────────
+  const DECISION_SEMANTICS = {
+    ALLOW:    'Action executed',
+    DENY:     'Action exists but blocked by policy',
+    ABSENT:   'Action does not exist in this world',
+    SIMULATE: 'Action simulated (no side effects)',
+  };
+
   // ── Decision → pipeline stage ────────────────────────────
   const PIPELINE_STAGES = [
     { label: 'Provenance', rules: [] },
@@ -305,7 +313,8 @@
 
   function badge(decision) {
     const cls = 'badge badge-' + (decision || 'ABSENT');
-    return `<span class="${cls}">${decision || '?'}</span>`;
+    const tip = DECISION_SEMANTICS[decision] || decision || '?';
+    return `<span class="${cls}" title="${tip}">${decision || '?'}</span>`;
   }
 
   // ── Render list ───────────────────────────────────────────
@@ -359,6 +368,8 @@
         <div class="field-grid">
           <span class="field-key">outcome</span>
           <span class="field-val">${badge(trace.decision)}</span>
+          <span class="field-key">meaning</span>
+          <span class="field-val">${DECISION_SEMANTICS[trace.decision] || ''}</span>
           <span class="field-key">rule</span>
           <span class="field-val">${trace.rule_hit}</span>
         </div>

--- a/ui/index.html
+++ b/ui/index.html
@@ -130,6 +130,41 @@
     td.col-dec   { width: 80px; }
     td.col-src   { width: 30%; color: #8b949e; }
 
+    /* ── Scenario bar ───────────────────────────────────── */
+    #scenario-bar {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-bottom: 1px solid #21262d;
+      flex-shrink: 0;
+      flex-wrap: wrap;
+    }
+
+    .scenario-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #6e7681;
+      margin-right: 2px;
+    }
+
+    .scenario-btn {
+      background: #21262d;
+      color: #c9d1d9;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-family: inherit;
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+
+    .scenario-btn:hover:not(:disabled) { background: #2d333b; color: #e6edf3; }
+    .scenario-btn:disabled { opacity: 0.5; cursor: default; }
+
     /* ── Decision badges ────────────────────────────────── */
     .badge {
       display: inline-block;
@@ -247,6 +282,13 @@
 <main>
   <section id="list-panel" aria-label="Trace list">
     <h2>Traces</h2>
+    <div id="scenario-bar">
+      <span class="scenario-label">Run:</span>
+      <button class="scenario-btn" data-scenario="benign_flow">Benign</button>
+      <button class="scenario-btn" data-scenario="prompt_injection">Injection</button>
+      <button class="scenario-btn" data-scenario="poisoned_descriptor">Poisoned</button>
+      <button class="scenario-btn" data-scenario="absent_tool">Absent</button>
+    </div>
     <div id="trace-table-wrap">
       <table id="trace-table" aria-label="Audit traces">
         <thead>
@@ -443,6 +485,36 @@
       statusEl.className = 'error';
     }
   }
+
+  // ── Scenario buttons ─────────────────────────────────────
+  const SCENARIO_LABELS = {
+    benign_flow:         'Benign',
+    prompt_injection:    'Injection',
+    poisoned_descriptor: 'Poisoned',
+    absent_tool:         'Absent',
+  };
+
+  async function runScenario(name, btn) {
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const res = await fetch(`/scenarios/${name}/run`, { method: 'POST' });
+      if (!res.ok) throw new Error(res.status);
+      const data = await res.json();
+      await fetchTraces();
+      if (data.trace_id != null) selectTrace(data.trace_id);
+    } catch (err) {
+      statusEl.textContent = `error: ${err.message}`;
+      statusEl.className = 'error';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = SCENARIO_LABELS[name] || name;
+    }
+  }
+
+  document.querySelectorAll('.scenario-btn').forEach(btn => {
+    btn.addEventListener('click', () => runScenario(btn.dataset.scenario, btn));
+  });
 
   fetchTraces();
   setInterval(fetchTraces, POLL_MS);


### PR DESCRIPTION
Adds a DECISION_SEMANTICS map with human-readable descriptions for each
decision outcome. The detail panel now shows a "meaning" row under the
decision badge, and list-view badges carry a tooltip title. Satisfies
DS1.2 (#60), DS1.3 (#61), and DS1.4 (#62) acceptance criteria.

https://claude.ai/code/session_01QwiCCZqhEvynGgyAc3tPNG