### PR TITLE
feat(DS3.2): add POST /compare endpoint for world comparison

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,17 +2,23 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
 
 import safe_mcp_proxy.scenarios as _scenarios
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.main import build_executor
 from safe_mcp_proxy.trace_store import TraceStore
+
+
+class CompareRequest(BaseModel):
+    scenario: str
+    worlds: List[str] = Field(min_length=1)
 
 
 def _default_base_dir() -> Path:
@@ -95,6 +101,32 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             "rule": outcome["result"]["rule"],
             "matches": outcome["matches"],
         }
+
+    @app.post("/compare")
+    async def compare_worlds(req: CompareRequest) -> dict:
+        try:
+            scenario = _scenarios.get(req.scenario)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+
+        from safe_mcp_proxy.provenance import Provenance
+
+        results = {}
+        for world_id in req.worlds:
+            try:
+                executor = build_executor(resolved_base_dir, world_id=world_id)
+            except FileNotFoundError:
+                raise HTTPException(status_code=404, detail=f"World not found: {world_id!r}")
+            if scenario.setup is not None:
+                scenario.setup(executor)
+            provenance = Provenance.from_source(scenario.source_channel)
+            outcome = executor.execute(scenario.tool, scenario.payload, provenance)
+            results[world_id] = {
+                "decision": outcome["decision"],
+                "rule": outcome["rule"],
+            }
+
+        return {"scenario": req.scenario, "worlds": results}
 
     @app.get("/stats")
     async def get_stats() -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,32 @@ class FastAPITests(unittest.TestCase):
         config_dir = self.tmp / "safe_mcp_proxy" / "config"
         config_dir.mkdir(parents=True)
         (config_dir / "policy.yaml").write_text("simulation:\n  external_side_effects: true\n", encoding="utf-8")
+        worlds_dir = config_dir / "worlds"
+        worlds_dir.mkdir()
+        (worlds_dir / "world_a.yaml").write_text(textwrap.dedent("""\
+            world_id: world_a
+            allowed_tools: [read_file, list_repo, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: true}
+              send_email: {allowed: true}
+              dangerous_exec: {allowed: false}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+        (worlds_dir / "world_b.yaml").write_text(textwrap.dedent("""\
+            world_id: world_b
+            allowed_tools: [read_file]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: false}
+              send_email: {allowed: false}
+              dangerous_exec: {allowed: false}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
         logs_dir = self.tmp / "safe_mcp_proxy" / "logs"
         logs_dir.mkdir(parents=True)
         self.audit_log = logs_dir / "audit.jsonl"
@@ -164,6 +190,46 @@ class FastAPITests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["access-control-allow-origin"], "*")
+
+
+    def test_compare_returns_decisions_per_world(self):
+        response = self._request(
+            "POST", "/compare",
+            json={"scenario": "benign_flow", "worlds": ["world_a", "world_b"]},
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["scenario"], "benign_flow")
+        self.assertIn("world_a", body["worlds"])
+        self.assertIn("world_b", body["worlds"])
+        self.assertEqual(body["worlds"]["world_a"]["decision"], "ALLOW")
+        self.assertEqual(body["worlds"]["world_b"]["decision"], "ALLOW")
+
+    def test_compare_shows_divergence_across_worlds(self):
+        response = self._request(
+            "POST", "/compare",
+            json={"scenario": "prompt_injection", "worlds": ["world_a", "world_b"]},
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["worlds"]["world_a"]["decision"], "DENY")
+        self.assertEqual(body["worlds"]["world_a"]["rule"], "tainted_external_side_effect")
+        self.assertEqual(body["worlds"]["world_b"]["decision"], "ABSENT")
+        self.assertEqual(body["worlds"]["world_b"]["rule"], "tool_not_allowlisted")
+
+    def test_compare_unknown_scenario_returns_404(self):
+        response = self._request(
+            "POST", "/compare",
+            json={"scenario": "nonexistent_scenario", "worlds": ["world_a"]},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_compare_unknown_world_returns_404(self):
+        response = self._request(
+            "POST", "/compare",
+            json={"scenario": "benign_flow", "worlds": ["no_such_world"]},
+        )
+        self.assertEqual(response.status_code, 404)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Accepts a scenario name and list of world IDs; runs the scenario
against each world independently and returns the decision and rule
per world, surfacing how the same input yields different outcomes
across policy contexts.

https://claude.ai/code/session_01SuNivhaMbQQLksfRQ3BMHo