### PR TITLE
feat(ds3): add World Diff Panel and permanent world configs

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -183,8 +183,134 @@
     /* ── Right panel ────────────────────────────────────── */
     #detail-panel {
       flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* ── Panel tabs ─────────────────────────────────────── */
+    #panel-tabs {
+      display: flex;
+      gap: 4px;
+      padding: 6px 10px;
+      border-bottom: 1px solid #21262d;
+      flex-shrink: 0;
+    }
+
+    .panel-tab {
+      background: #21262d;
+      color: #6e7681;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-family: inherit;
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+
+    .panel-tab:hover { background: #2d333b; color: #c9d1d9; }
+    .panel-tab.active { background: #1a3a5c; color: #58a6ff; border-color: #1a3a5c; }
+
+    #detail-view {
+      flex: 1;
       overflow-y: auto;
       padding: 16px 20px;
+    }
+
+    /* ── Compare panel ──────────────────────────────────── */
+    #compare-panel {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    }
+
+    #compare-panel select {
+      background: #21262d;
+      color: #c9d1d9;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-family: inherit;
+      font-size: 12px;
+      width: 100%;
+      margin-top: 4px;
+    }
+
+    .cmp-worlds {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-top: 4px;
+    }
+
+    .cmp-world-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #c9d1d9;
+      font-size: 12px;
+      cursor: pointer;
+    }
+
+    .cmp-world-label input[type=checkbox] {
+      accent-color: #58a6ff;
+      width: 14px;
+      height: 14px;
+    }
+
+    #cmp-run-btn {
+      margin-top: 14px;
+      background: #1a3a5c;
+      color: #58a6ff;
+      border: 1px solid #1f4d7a;
+      border-radius: 4px;
+      padding: 5px 16px;
+      font-family: inherit;
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 0.1s;
+    }
+
+    #cmp-run-btn:hover:not(:disabled) { background: #1f4d7a; }
+    #cmp-run-btn:disabled { opacity: 0.5; cursor: default; }
+
+    #cmp-result { margin-top: 16px; }
+
+    .cmp-banner {
+      padding: 6px 10px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      margin-bottom: 10px;
+    }
+
+    .cmp-diverged  { background: #3d2200; color: #e3b341; }
+    .cmp-converged { background: #1a3d1a; color: #3fb950; }
+
+    .cmp-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    .cmp-table thead th {
+      background: #161b22;
+      color: #6e7681;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 5px 10px;
+      text-align: left;
+      border-bottom: 1px solid #21262d;
+    }
+
+    .cmp-table tbody td {
+      padding: 5px 10px;
+      border-bottom: 1px solid #161b22;
+      color: #c9d1d9;
     }
 
     #detail-panel .placeholder {
@@ -307,8 +433,41 @@
   </section>
 
   <section id="detail-panel" aria-label="Trace detail">
-    <p class="placeholder" id="detail-placeholder">Select a trace to see details.</p>
-    <div id="detail-content" style="display:none"></div>
+    <div id="panel-tabs">
+      <button class="panel-tab active" data-panel="detail">Detail</button>
+      <button class="panel-tab" data-panel="compare">World Diff</button>
+    </div>
+    <div id="detail-view">
+      <p class="placeholder" id="detail-placeholder">Select a trace to see details.</p>
+      <div id="detail-content" style="display:none"></div>
+    </div>
+    <div id="compare-panel" style="display:none">
+      <div class="detail-section">
+        <h3>Scenario</h3>
+        <select id="cmp-scenario">
+          <option value="benign_flow">benign_flow</option>
+          <option value="prompt_injection">prompt_injection</option>
+          <option value="poisoned_descriptor">poisoned_descriptor</option>
+          <option value="absent_tool">absent_tool</option>
+        </select>
+      </div>
+      <div class="detail-section">
+        <h3>Worlds</h3>
+        <div class="cmp-worlds">
+          <label class="cmp-world-label">
+            <input type="checkbox" class="cmp-world" value="world_a" checked> world_a — full access
+          </label>
+          <label class="cmp-world-label">
+            <input type="checkbox" class="cmp-world" value="world_b" checked> world_b — read-only
+          </label>
+          <label class="cmp-world-label">
+            <input type="checkbox" class="cmp-world" value="world_c" checked> world_c — no email
+          </label>
+        </div>
+      </div>
+      <button id="cmp-run-btn">Compare</button>
+      <div id="cmp-result"></div>
+    </div>
   </section>
 </main>
 
@@ -518,6 +677,71 @@
 
   fetchTraces();
   setInterval(fetchTraces, POLL_MS);
+
+  // ── Panel tab switching ───────────────────────────────
+  let activePanel = 'detail';
+
+  function switchPanel(name) {
+    activePanel = name;
+    document.querySelectorAll('.panel-tab').forEach(t =>
+      t.classList.toggle('active', t.dataset.panel === name));
+    document.getElementById('detail-view').style.display    = name === 'detail'  ? '' : 'none';
+    document.getElementById('compare-panel').style.display  = name === 'compare' ? '' : 'none';
+  }
+
+  document.querySelectorAll('.panel-tab').forEach(tab => {
+    tab.addEventListener('click', () => switchPanel(tab.dataset.panel));
+  });
+
+  // ── Compare / World Diff ──────────────────────────────
+  async function runCompare() {
+    const scenario = document.getElementById('cmp-scenario').value;
+    const worlds = [...document.querySelectorAll('.cmp-world:checked')].map(cb => cb.value);
+    if (!worlds.length) return;
+    const btn = document.getElementById('cmp-run-btn');
+    btn.disabled = true;
+    btn.textContent = '…';
+    document.getElementById('cmp-result').innerHTML = '';
+    try {
+      const res = await fetch('/compare', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scenario, worlds }),
+      });
+      if (!res.ok) throw new Error(res.status);
+      const data = await res.json();
+      renderCompareResults(data);
+    } catch (err) {
+      document.getElementById('cmp-result').innerHTML =
+        `<span style="color:#f85149">Error: ${err.message}</span>`;
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Compare';
+    }
+  }
+
+  function renderCompareResults(data) {
+    const worldResults = data.worlds;
+    const decisions = Object.values(worldResults).map(r => r.decision);
+    const diverged = new Set(decisions).size > 1;
+
+    const banner = diverged
+      ? `<div class="cmp-banner cmp-diverged">DIVERGED — worlds disagree</div>`
+      : `<div class="cmp-banner cmp-converged">CONVERGED — all worlds agree</div>`;
+
+    const rows = Object.entries(worldResults).map(([world, r]) =>
+      `<tr><td>${world}</td><td>${badge(r.decision)}</td><td>${r.rule}</td></tr>`
+    ).join('');
+
+    document.getElementById('cmp-result').innerHTML = `
+      ${banner}
+      <table class="cmp-table">
+        <thead><tr><th>World</th><th>Decision</th><th>Rule</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
+  document.getElementById('cmp-run-btn').addEventListener('click', runCompare);
 </script>
 </body>
 </html>

--- a/worlds/world_a.yaml
+++ b/worlds/world_a.yaml
@@ -1,0 +1,22 @@
+world_id: "world_a"
+
+allowed_tools:
+  - read_file
+  - list_repo
+  - send_email
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: true
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/worlds/world_b.yaml
+++ b/worlds/world_b.yaml
@@ -1,0 +1,20 @@
+world_id: "world_b"
+
+allowed_tools:
+  - read_file
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: false
+  send_email:
+    allowed: false
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted

--- a/worlds/world_c.yaml
+++ b/worlds/world_c.yaml
@@ -1,0 +1,21 @@
+world_id: "world_c"
+
+allowed_tools:
+  - read_file
+  - list_repo
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: false
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted


### PR DESCRIPTION
- Add worlds/world_a.yaml (full access), world_b.yaml (read-only),
  world_c.yaml (no email) so the /compare endpoint is usable from the UI
- Add World Diff tab to ui/index.html: scenario selector, world
  checkboxes, Compare button, results table with DIVERGED/CONVERGED banner
- Decisions rendered with existing badge colour scheme (ALLOW/DENY/ABSENT)

Closes #67, #68

https://claude.ai/code/session_01U8VipfniDF219iJQTjRh1M