### PR TITLE
DS5 + DS6: export, bundle, seed, and one-click launcher

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import json
 from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from pydantic import BaseModel, Field
 
 import safe_mcp_proxy.scenarios as _scenarios
@@ -30,6 +32,18 @@ def _build_trace_store(base_dir: Path) -> TraceStore:
     return TraceStore(str(audit_log_path))
 
 
+def _seed_demo_data(base_dir: Path) -> None:
+    """Populate audit.jsonl with one trace per decision type if the log is empty."""
+    audit_log = base_dir / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+    if audit_log.exists() and audit_log.stat().st_size > 0:
+        return
+    for name in ("benign_flow", "prompt_injection", "poisoned_descriptor", "absent_tool"):
+        try:
+            _scenarios.run(name, base_dir=base_dir)
+        except Exception:
+            pass
+
+
 def _find_trace(trace_store: TraceStore, trace_id: int):
     for trace in trace_store.all():
         if trace.id == trace_id:
@@ -49,6 +63,7 @@ def _trace_to_audit_entry(trace) -> dict:
 
 def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = None) -> FastAPI:
     resolved_base_dir = base_dir or _default_base_dir()
+    _seed_demo_data(resolved_base_dir)
     app = FastAPI(title="safe-mcp-proxy API")
     app.state.trace_store = _build_trace_store(resolved_base_dir)
     app.state.executor = executor or build_executor(resolved_base_dir)
@@ -72,9 +87,38 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
         traces = app.state.trace_store.last(limit)
         return {"traces": [trace.as_dict() for trace in traces]}
 
+    @app.get("/traces/export")
+    async def export_traces(limit: int = Query(default=1000, ge=1, le=10000)) -> Response:
+        traces = app.state.trace_store.last(limit)
+        content = json.dumps([t.as_dict() for t in traces], indent=2)
+        return Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": "attachment; filename=traces.json"},
+        )
+
     @app.get("/traces/{trace_id}")
     async def get_trace(trace_id: int) -> dict:
         return _find_trace(app.state.trace_store, trace_id).as_dict()
+
+    @app.get("/bundle")
+    async def export_bundle() -> Response:
+        traces = app.state.trace_store.all()
+        manifest_path = resolved_base_dir / "world_manifest.yaml"
+        manifest_text = manifest_path.read_text(encoding="utf-8") if manifest_path.exists() else ""
+        bundle = {
+            "schema_version": 1,
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "traces": [t.as_dict() for t in traces],
+            "world_manifest": manifest_text,
+            "scenarios": _scenarios.names(),
+        }
+        content = json.dumps(bundle, indent=2)
+        return Response(
+            content=content,
+            media_type="application/json",
+            headers={"Content-Disposition": "attachment; filename=safe-mcp-proxy-bundle.json"},
+        )
 
     @app.post("/replay/{trace_id}")
     async def replay_trace(trace_id: int) -> dict:

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""One-click launcher: starts the safe-mcp-proxy API and opens the UI in a browser.
+
+Usage:
+    python run_demo.py
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+HOST = "http://localhost:8000"
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def _server_ready(url: str) -> bool:
+    try:
+        urllib.request.urlopen(url, timeout=1)
+        return True
+    except Exception:
+        return False
+
+
+def _wait_ready(url: str, timeout: int = 30) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _server_ready(url):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+if __name__ == "__main__":
+    print("safe-mcp-proxy — starting server...")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"],
+        cwd=str(BASE_DIR),
+    )
+    try:
+        print(f"Waiting for {HOST} ...", end="", flush=True)
+        if _wait_ready(HOST):
+            print(" ready")
+            webbrowser.open(HOST)
+            print(f"UI open at {HOST}  (Ctrl+C to stop)")
+            proc.wait()
+        else:
+            print(" timed out")
+            proc.terminate()
+            sys.exit(1)
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        proc.terminate()

--- a/ui/index.html
+++ b/ui/index.html
@@ -460,6 +460,8 @@
       <button class="scenario-btn" data-scenario="prompt_injection">Injection</button>
       <button class="scenario-btn" data-scenario="poisoned_descriptor">Poisoned</button>
       <button class="scenario-btn" data-scenario="absent_tool">Absent</button>
+      <span class="scenario-label" style="margin-left:auto">Export:</span>
+      <button class="scenario-btn" id="export-bundle-btn">↓ Bundle</button>
     </div>
     <div id="trace-table-wrap">
       <table id="trace-table" aria-label="Audit traces">
@@ -486,6 +488,9 @@
     <div id="detail-view">
       <p class="placeholder" id="detail-placeholder">Select a trace to see details.</p>
       <div id="detail-content" style="display:none"></div>
+      <div id="detail-export" style="display:none; padding: 0 0 16px 0;">
+        <button class="scenario-btn" id="export-trace-btn">↓ Export JSON</button>
+      </div>
     </div>
     <div id="compare-panel" style="display:none">
       <div class="detail-section">
@@ -746,7 +751,45 @@
 
     detailPH.style.display = 'none';
     detailDiv.style.display = 'block';
+    document.getElementById('detail-export').style.display = 'block';
     renderDetail(trace);
+  }
+
+  // ── Export ───────────────────────────────────────────────
+  function _download(filename, obj) {
+    const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function exportTrace() {
+    if (selectedId === null) return;
+    const trace = traces.find(t => t.id === selectedId);
+    if (trace) _download(`trace_${trace.id}.json`, trace);
+  }
+
+  async function exportBundle() {
+    const btn = document.getElementById('export-bundle-btn');
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+      const res = await fetch('/bundle');
+      if (!res.ok) throw new Error(res.status);
+      const data = await res.json();
+      _download('safe-mcp-proxy-bundle.json', data);
+    } catch (err) {
+      statusEl.textContent = `error: ${err.message}`;
+      statusEl.className = 'error';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = '↓ Bundle';
+    }
   }
 
   // ── Fetch & poll ──────────────────────────────────────────
@@ -872,6 +915,8 @@
   }
 
   document.getElementById('cmp-run-btn').addEventListener('click', runCompare);
+  document.getElementById('export-trace-btn').addEventListener('click', exportTrace);
+  document.getElementById('export-bundle-btn').addEventListener('click', exportBundle);
 </script>
 </body>
 </html>


### PR DESCRIPTION
- DS5.1: Add GET /traces/export endpoint and "↓ Export JSON" button in
  the detail panel — downloads the selected trace as trace_<id>.json
- DS5.2: Add GET /bundle endpoint and "↓ Bundle" button in the scenario
  bar — downloads all traces + world manifest + scenario list as a
  single shareable JSON bundle (safe-mcp-proxy-bundle.json)
- DS6.1: _seed_demo_data() runs all four scenarios on startup when
  audit.jsonl is absent or empty, ensuring the UI is never blank on
  first launch (covers ALLOW, DENY×2, ABSENT)
- DS6.2: Add run_demo.py — starts uvicorn, polls until ready, then
  opens the browser automatically (python run_demo.py)
- DS6.3: GIF/screen recording left for manual capture (requires live UI)

https://claude.ai/code/session_014wBRvxWox9rCJeDeFBmjJz