### PR TITLE
refactor: standardise Copilot/sv-pro code to house style

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ import safe_mcp_proxy.scenarios as _scenarios
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.main import build_executor
+from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.trace_store import TraceStore
 
 
@@ -109,8 +110,6 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
 
-        from safe_mcp_proxy.provenance import Provenance
-
         results = {}
         for world_id in req.worlds:
             try:
@@ -131,9 +130,6 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     @app.get("/stats")
     async def get_stats() -> dict:
         counts = Counter(trace.decision for trace in app.state.trace_store.all())
-        # Future interaction semantics are tracked in GitHub:
-        #   - #77: ASK decision and approval workflow
-        #   - #78: execution modes (INTERACTIVE and BACKGROUND)
         decision_counts = {
             decision.value: counts.get(decision, 0)
             for decision in Decision

--- a/safe_mcp_proxy/executor.py
+++ b/safe_mcp_proxy/executor.py
@@ -1,13 +1,13 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.descriptor import compute_descriptor_hash, descriptor_hash_valid
 from safe_mcp_proxy.policy_engine import PolicyEngine
 from safe_mcp_proxy.provenance import Provenance
-from safe_mcp_proxy.registry import ToolRegistry
+from safe_mcp_proxy.registry import Tool, ToolRegistry
 from safe_mcp_proxy.simulate import simulate_external_action
 
 ABSENT_MESSAGE = "Action does not exist in this world"
@@ -26,11 +26,15 @@ class Executor:
         self.simulate_external = simulate_external
         self.audit_log_path = Path(audit_log_path)
 
-    def execute(self, tool_name: str, payload: Dict[str, Any], provenance: Provenance) -> Dict[str, Any]:
+    def _tool_context(self, tool_name: str) -> Tuple[Optional[Tool], str, str, bool]:
         tool = self.registry.get_tool(tool_name)
         capability = tool.capability if tool else tool_name
         side_effect_type = tool.side_effect_type if tool else "unknown"
-        descriptor_hash_ok = descriptor_hash_valid(tool.schema, tool.descriptor_hash) if tool else True
+        hash_ok = descriptor_hash_valid(tool.schema, tool.descriptor_hash) if tool else True
+        return tool, capability, side_effect_type, hash_ok
+
+    def execute(self, tool_name: str, payload: Dict[str, Any], provenance: Provenance) -> Dict[str, Any]:
+        tool, capability, side_effect_type, hash_ok = self._tool_context(tool_name)
         descriptor_hash = compute_descriptor_hash(tool.schema) if tool else ""
 
         policy = self.policy_engine.decide(
@@ -38,7 +42,7 @@ class Executor:
             capability=capability,
             taint=provenance.tainted,
             side_effect_type=side_effect_type,
-            descriptor_hash_valid=descriptor_hash_ok,
+            descriptor_hash_valid=hash_ok,
         )
 
         if policy.decision == Decision.ALLOW:
@@ -65,17 +69,14 @@ class Executor:
         tool_name = audit_entry["tool"]
         tainted = audit_entry["taint"]
 
-        tool = self.registry.get_tool(tool_name)
-        capability = tool.capability if tool else tool_name
-        side_effect_type = tool.side_effect_type if tool else "unknown"
-        descriptor_hash_ok = descriptor_hash_valid(tool.schema, tool.descriptor_hash) if tool else True
+        _, capability, side_effect_type, hash_ok = self._tool_context(tool_name)
 
         policy = self.policy_engine.decide(
             tool_name=tool_name,
             capability=capability,
             taint=tainted,
             side_effect_type=side_effect_type,
-            descriptor_hash_valid=descriptor_hash_ok,
+            descriptor_hash_valid=hash_ok,
         )
 
         matches = policy.decision.value == audit_entry["decision"] and policy.rule_hit == audit_entry["rule"]

--- a/safe_mcp_proxy/logs/audit.jsonl
+++ b/safe_mcp_proxy/logs/audit.jsonl
@@ -19,3 +19,4 @@
 {"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T15:47:40.038909+00:00", "tool": "dangerous_exec"}
 {"decision": "ALLOW", "descriptor_hash": "53582d9d7229826e75097ac478787ca403c94ce74e4611571be1b03c706952cc", "rule": "default_allow", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T15:50:44.186168+00:00", "tool": "read_file"}
 {"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T15:51:50.464486+00:00", "tool": "dangerous_exec"}
+{"decision": "ALLOW", "descriptor_hash": "53582d9d7229826e75097ac478787ca403c94ce74e4611571be1b03c706952cc", "rule": "default_allow", "source_channel": "cli", "taint": false, "timestamp": "2026-04-24T04:06:42.616482+00:00", "tool": "read_file"}

--- a/safe_mcp_proxy/opa_engine.py
+++ b/safe_mcp_proxy/opa_engine.py
@@ -1,17 +1,4 @@
-"""OPAPolicyEngine — evaluates safe_mcp_proxy/policies/proxy.rego via OPA.
-
-Two evaluation strategies are supported:
-
-* ``"subprocess"`` (default) — spawns ``opa eval`` for every decision.
-  Requires the ``opa`` binary on PATH.  No extra Python dependencies.
-
-* ``"rest"`` — POSTs to a running OPA server
-  (``opa run --server``, default address ``http://localhost:8181``).
-  Uses only stdlib ``urllib.request``; no extra Python dependencies.
-
-Both strategies implement the same interface as ``PolicyEngine`` so they are
-a transparent drop-in replacement inside ``Executor``.
-"""
+"""OPA-backed policy engine — subprocess and REST evaluation strategies."""
 
 from __future__ import annotations
 
@@ -31,15 +18,7 @@ _DEFAULT_REST_URL = "http://localhost:8181/v1/data/safe_mcp_proxy/decision"
 
 
 class OPAPolicyEngine:
-    """Policy engine that delegates decisions to OPA/Rego.
-
-    Args:
-        policy_path: Absolute or relative path to ``proxy.rego``.
-        allowlist:   Iterable of tool names permitted in this world.
-        capability_map: Mapping of capability name → enabled flag.
-        evaluator:   ``"subprocess"`` or ``"rest"``.
-        opa_url:     OPA server URL (only used when *evaluator* is ``"rest"``).
-    """
+    """Evaluates decisions via OPA/Rego; drop-in replacement for PolicyEngine."""
 
     def __init__(
         self,
@@ -62,10 +41,6 @@ class OPAPolicyEngine:
                 "or switch to evaluator='rest' and run `opa run --server`."
             )
 
-    # ------------------------------------------------------------------
-    # Public interface (mirrors PolicyEngine.decide)
-    # ------------------------------------------------------------------
-
     def decide(
         self,
         tool_name: str,
@@ -74,7 +49,6 @@ class OPAPolicyEngine:
         side_effect_type: str,
         descriptor_hash_valid: bool,
     ) -> PolicyResult:
-        """Evaluate the Rego policy and return a :class:`PolicyResult`."""
         opa_input = build_opa_input(
             tool_name=tool_name,
             capability=capability,
@@ -95,12 +69,7 @@ class OPAPolicyEngine:
             rule_hit=raw["rule"],
         )
 
-    # ------------------------------------------------------------------
-    # Subprocess evaluator
-    # ------------------------------------------------------------------
-
     def _eval_subprocess(self, opa_input: dict) -> dict:
-        """Run ``opa eval`` in a subprocess and parse the result."""
         input_json = json.dumps(opa_input)
         cmd = [
             "opa",
@@ -134,12 +103,7 @@ class OPAPolicyEngine:
                 f"OPA returned non-JSON output: {proc.stdout!r}"
             ) from exc
 
-    # ------------------------------------------------------------------
-    # REST evaluator
-    # ------------------------------------------------------------------
-
     def _eval_rest(self, opa_input: dict) -> dict:
-        """POST to a running OPA server and parse the result."""
         body = json.dumps({"input": opa_input}).encode("utf-8")
         req = urllib.request.Request(
             self._opa_url,

--- a/safe_mcp_proxy/registry.py
+++ b/safe_mcp_proxy/registry.py
@@ -34,10 +34,26 @@ class ToolRegistry:
             return {"ok": True, "sent_to": payload.get("to", "unknown@example.com")}
 
         tool_defs = [
-            ("read_file", "read_file", {"type": "object", "properties": {"path": {"type": "string"}}}, "read", _read_file),
-            ("list_repo", "list_repo", {"type": "object", "properties": {}}, "internal", _list_repo),
-            ("send_email", "send_email", {"type": "object", "properties": {"to": {"type": "string"}, "body": {"type": "string"}}}, "external", _send_email),
-            ("dangerous_exec", "dangerous_exec", {"type": "object", "properties": {"cmd": {"type": "string"}}}, "external", lambda payload: {"ok": True, "cmd": payload.get("cmd")}),
+            (
+                "read_file", "read_file",
+                {"type": "object", "properties": {"path": {"type": "string"}}},
+                "read", _read_file,
+            ),
+            (
+                "list_repo", "list_repo",
+                {"type": "object", "properties": {}},
+                "internal", _list_repo,
+            ),
+            (
+                "send_email", "send_email",
+                {"type": "object", "properties": {"to": {"type": "string"}, "body": {"type": "string"}}},
+                "external", _send_email,
+            ),
+            (
+                "dangerous_exec", "dangerous_exec",
+                {"type": "object", "properties": {"cmd": {"type": "string"}}},
+                "external", lambda payload: {"ok": True, "cmd": payload.get("cmd")},
+            ),
         ]
 
         tools = [

--- a/safe_mcp_proxy/trace_store.py
+++ b/safe_mcp_proxy/trace_store.py
@@ -1,18 +1,3 @@
-"""TraceStore — read-only, queryable view over the append-only audit JSONL log.
-
-Stable record format (schema_version=1):
-    id              — 1-based line number within the file
-    schema_version  — int, always 1 for this format
-    timestamp       — ISO-8601 UTC string (from audit entry)
-    tool_requested  — tool name (audit field: "tool")
-    decision        — ALLOW | DENY | ABSENT | SIMULATE
-    rule_hit        — rule name (audit field: "rule")
-    source_channel  — cli | web | email | tool_output
-    taint           — bool
-    descriptor_hash — SHA-256 hex string (empty string when absent)
-    input           — dict | None  (not yet captured by executor; reserved)
-"""
-
 from __future__ import annotations
 
 import json
@@ -55,7 +40,6 @@ class TraceRecord:
 
     @staticmethod
     def from_raw(line_number: int, raw: dict) -> "TraceRecord":
-        """Normalize one raw audit-log dict into a TraceRecord."""
         return TraceRecord(
             id=line_number,
             schema_version=SCHEMA_VERSION,
@@ -71,7 +55,6 @@ class TraceRecord:
 
 
 def _parse_timestamp(ts: str) -> Optional[datetime]:
-    """Parse an ISO-8601 timestamp into an aware UTC datetime, or None on failure."""
     if not ts:
         return None
     try:
@@ -89,16 +72,10 @@ class TraceStore:
     def __init__(self, audit_log_path: str) -> None:
         self._path = Path(audit_log_path)
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
-
     def all(self) -> List[TraceRecord]:
-        """Return every record in chronological order."""
         return list(self._iter_records())
 
     def last(self, n: int) -> List[TraceRecord]:
-        """Return the last *n* records (most-recent last)."""
         if n <= 0:
             return []
         records = self.all()
@@ -112,14 +89,7 @@ class TraceStore:
         since: Optional[datetime] = None,
         until: Optional[datetime] = None,
     ) -> List[TraceRecord]:
-        """Return records matching every supplied criterion.
-
-        Args:
-            decision: exact match on the ``decision`` field (ALLOW/DENY/ABSENT/SIMULATE).
-            tool:     exact match on ``tool_requested``.
-            since:    include only records with timestamp >= since (tz-aware datetime).
-            until:    include only records with timestamp <= until (tz-aware datetime).
-        """
+        """Return records matching every supplied criterion (keyword-only)."""
         results = []
         expected_decision = Decision.parse(decision) if isinstance(decision, str) else decision
         for rec in self._iter_records():
@@ -138,12 +108,7 @@ class TraceStore:
             results.append(rec)
         return results
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
     def _iter_records(self):
-        """Yield TraceRecord objects line by line from the JSONL file."""
         if not self._path.exists():
             return
         with self._path.open(encoding="utf-8") as fh:

--- a/tests/test_opa_engine.py
+++ b/tests/test_opa_engine.py
@@ -1,13 +1,4 @@
-"""tests/test_opa_engine.py — Parity and integration tests for OPAPolicyEngine.
-
-These tests mirror the decision-level assertions from test_proxy.py but wire
-OPAPolicyEngine in place of PolicyEngine.  The full executor integration tests
-confirm that the Executor + OPAPolicyEngine pipeline produces identical outputs
-to the Executor + PolicyEngine pipeline for every supported decision path.
-
-All tests are skipped automatically when the ``opa`` binary is not on PATH so
-the suite degrades gracefully in environments without OPA installed.
-"""
+"""Parity and integration tests for OPAPolicyEngine vs PolicyEngine."""
 
 import shutil
 import tempfile
@@ -52,13 +43,7 @@ def _make_python_engine() -> PolicyEngine:
     return PolicyEngine(allowlist=_ALLOWLIST, capability_map=_CAPABILITY_MAP)
 
 
-# ---------------------------------------------------------------------------
-# Helper: all five (input, expected) test vectors shared by both test classes
-# ---------------------------------------------------------------------------
-
 _DECISION_VECTORS = [
-    # (tool_name, capability, taint, side_effect_type, descriptor_hash_valid,
-    #  expected_decision, expected_rule)
     ("read_file", "read_file", False, "read", True, Decision.ALLOW, "default_allow"),
     ("list_repo", "list_repo", False, "internal", True, Decision.ALLOW, "default_allow"),
     ("send_email", "send_email", True, "external", True, Decision.DENY, "tainted_external_side_effect"),
@@ -105,7 +90,6 @@ class TestOPAPolicyEngineDecide(unittest.TestCase):
         self._check_vector("dangerous_exec", "dangerous_exec", False, "external", True, Decision.ABSENT, "tool_not_allowlisted")
 
     def test_capability_not_allowed_is_absent(self):
-        # Use an engine with send_email capability disabled
         opa = OPAPolicyEngine(
             policy_path=_POLICY_PATH,
             allowlist=["read_file", "list_repo", "send_email"],
@@ -205,15 +189,10 @@ class TestBuildOpaInput(unittest.TestCase):
         self.assertEqual(result["capability_map"], {"read_file": True})
 
     def test_allowlist_is_list(self):
-        # Accepts an arbitrary iterable and normalises it to a list
         result = build_opa_input("x", "x", False, "read", True, ("a", "b"), {})
         self.assertIsInstance(result["allowlist"], list)
 
     def test_capability_map_is_dict(self):
-        class _Proxy:
-            def items(self):
-                return {"a": True}.items()
-
         result = build_opa_input("x", "x", False, "read", True, [], {"a": True})
         self.assertIsInstance(result["capability_map"], dict)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -13,7 +13,7 @@ from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.registry import ToolRegistry
 
 
-class SafeMCPProxyTests(unittest.TestCase):
+class TestProxy(unittest.TestCase):
     def setUp(self):
         self.registry = ToolRegistry.with_mock_tools(["read_file", "list_repo", "send_email"])
         self.policy = PolicyEngine(

--- a/tests/test_trace_store.py
+++ b/tests/test_trace_store.py
@@ -1,4 +1,4 @@
-"""Tests for TraceStore (DS0.1)."""
+"""Tests for TraceStore."""
 
 import json
 import tempfile


### PR DESCRIPTION
Strip multi-paragraph docstrings, Args: sections, and # --- separator
comments from Copilot-authored files (opa_engine, trace_store,
test_opa_engine). Hoist inline Provenance import and remove ephemeral
issue-number comments from api/main.py. Extract duplicated tool
property resolution into Executor._tool_context(). Reformat overlong
registry tool_defs tuples. Rename SafeMCPProxyTests -> TestProxy.

https://claude.ai/code/session_016qxD8uq5A3AAxcST2U2GSC