### PR TITLE
Implement DS5 — export & sharing (issues #71 and #72)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 import safe_mcp_proxy.scenarios as _scenarios
+from safe_mcp_proxy.compiler import compile_world_manifest
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.main import build_executor
@@ -126,6 +127,44 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             }
 
         return {"scenario": req.scenario, "worlds": results}
+
+    @app.get("/export/bundle")
+    async def export_bundle(
+        scenario: str = Query(...),
+        trace_id: Optional[int] = Query(default=None),
+    ) -> dict:
+        try:
+            scn = _scenarios.get(scenario)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+
+        manifest = compile_world_manifest(
+            str(resolved_base_dir / "world_manifest.yaml")
+        )
+
+        if trace_id is not None:
+            trace = _find_trace(app.state.trace_store, trace_id)
+            trace_dicts = [trace.as_dict()]
+        else:
+            recent = app.state.trace_store.last(1)
+            trace_dicts = [recent[0].as_dict()] if recent else []
+
+        from datetime import datetime, timezone
+        return {
+            "schema_version": 1,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "scenario": {
+                "name": scn.name,
+                "description": scn.description,
+                "tool": scn.tool,
+                "payload": scn.payload,
+                "source_channel": scn.source_channel,
+                "expected_decision": scn.expected_decision,
+                "expected_rule": scn.expected_rule,
+            },
+            "manifest": manifest,
+            "traces": trace_dicts,
+        }
 
     @app.get("/stats")
     async def get_stats() -> dict:

--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,17 @@ def _build_trace_store(base_dir: Path) -> TraceStore:
     return TraceStore(str(audit_log_path))
 
 
+def _seed_if_empty(base_dir: Path) -> None:
+    audit_path = base_dir / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+    seed_path = base_dir / "seeds" / "demo.jsonl"
+    if not seed_path.exists():
+        return
+    if audit_path.exists() and audit_path.stat().st_size > 0:
+        return
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_path.write_text(seed_path.read_text(encoding="utf-8"), encoding="utf-8")
+
+
 def _find_trace(trace_store: TraceStore, trace_id: int):
     for trace in trace_store.all():
         if trace.id == trace_id:
@@ -51,6 +62,7 @@ def _trace_to_audit_entry(trace) -> dict:
 
 def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = None) -> FastAPI:
     resolved_base_dir = base_dir or _default_base_dir()
+    _seed_if_empty(resolved_base_dir)
     app = FastAPI(title="safe-mcp-proxy API")
     app.state.trace_store = _build_trace_store(resolved_base_dir)
     app.state.executor = executor or build_executor(resolved_base_dir)

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""One-click demo launcher for safe-mcp-proxy.
+
+Usage:
+    python run_demo.py [--port PORT]
+"""
+import argparse
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+_BASE = Path(__file__).resolve().parent
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
+
+def _ensure_uvicorn() -> None:
+    try:
+        import uvicorn  # noqa: F401
+    except ImportError:
+        print("Installing uvicorn…", flush=True)
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "uvicorn", "--quiet"],
+            check=True,
+        )
+
+
+def _wait_ready(url: str, timeout: float = 15.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            urlopen(f"{url}/stats", timeout=1)
+            return True
+        except (URLError, OSError):
+            time.sleep(0.3)
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch safe-mcp-proxy demo")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    args = parser.parse_args()
+
+    url = f"http://{args.host}:{args.port}"
+
+    _ensure_uvicorn()
+
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "uvicorn",
+            "api.main:app",
+            "--host", args.host,
+            "--port", str(args.port),
+            "--no-access-log",
+        ],
+        cwd=str(_BASE),
+    )
+
+    print(f"Starting safe-mcp-proxy at {url} …", flush=True)
+
+    if not _wait_ready(url):
+        proc.terminate()
+        sys.exit("Server did not become ready in time.")
+
+    print(f"Ready → {url}", flush=True)
+    webbrowser.open(url)
+    print("Press Ctrl+C to stop.", flush=True)
+
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        print("\nShutting down…", flush=True)
+        proc.terminate()
+        proc.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/safe_mcp_proxy/bundle_replay.py
+++ b/safe_mcp_proxy/bundle_replay.py
@@ -1,0 +1,55 @@
+"""Offline bundle replayer — replay policy decisions from a saved demo bundle.
+
+Usage:
+    python -m safe_mcp_proxy.bundle_replay path/to/bundle.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict
+
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.policy_engine import PolicyEngine
+from safe_mcp_proxy.registry import ToolRegistry
+
+
+def replay_bundle(bundle: Dict[str, Any]) -> Dict[str, Any]:
+    manifest = bundle["manifest"]
+    registry = ToolRegistry.with_mock_tools(allowlist=manifest["allowlist"])
+    policy_engine = PolicyEngine(
+        allowlist=manifest["allowlist"],
+        capability_map=manifest["capability_map"],
+    )
+    executor = Executor(
+        registry=registry,
+        policy_engine=policy_engine,
+        audit_log_path=os.devnull,
+        simulate_external=False,
+    )
+
+    results = []
+    for trace in bundle.get("traces", []):
+        audit_entry = {
+            "tool": trace["tool_requested"],
+            "taint": trace["taint"],
+            "decision": trace["decision"],
+            "rule": trace["rule_hit"],
+        }
+        result = executor.replay(audit_entry)
+        results.append({"trace_id": trace["id"], **result})
+
+    total = len(results)
+    matched = sum(1 for r in results if r["matches"])
+    return {"total": total, "matched": matched, "diverged": total - matched, "results": results}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python -m safe_mcp_proxy.bundle_replay <bundle.json>", file=sys.stderr)
+        sys.exit(1)
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        bundle = json.load(fh)
+    summary = replay_bundle(bundle)
+    print(json.dumps(summary, indent=2))

--- a/seeds/demo.jsonl
+++ b/seeds/demo.jsonl
@@ -1,0 +1,4 @@
+{"decision": "ALLOW", "descriptor_hash": "53582d9d7229826e75097ac478787ca403c94ce74e4611571be1b03c706952cc", "rule": "default_allow", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T06:00:00.000000+00:00", "tool": "read_file"}
+{"decision": "DENY", "descriptor_hash": "45dfabdd32b140f2c22605b588d85ff3b54d14f5cc1e848932e048bd9b6db5d0", "rule": "tainted_external_side_effect", "source_channel": "web", "taint": true, "timestamp": "2026-04-22T06:01:00.000000+00:00", "tool": "send_email"}
+{"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T06:02:00.000000+00:00", "tool": "dangerous_exec"}
+{"decision": "SIMULATE", "descriptor_hash": "45dfabdd32b140f2c22605b588d85ff3b54d14f5cc1e848932e048bd9b6db5d0", "rule": "simulate_external_action", "source_channel": "cli", "taint": false, "timestamp": "2026-04-22T06:03:00.000000+00:00", "tool": "send_email"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -300,5 +300,76 @@ class TestExportBundle(unittest.TestCase):
         self.assertEqual(body["traces"][0]["id"], trace_id)
 
 
+class TestSeedDemoData(unittest.TestCase):
+    SEED_CONTENT = (
+        '{"decision": "ALLOW", "descriptor_hash": "aaa", "rule": "default_allow", '
+        '"source_channel": "cli", "taint": false, "timestamp": "2026-01-01T00:00:00+00:00", "tool": "read_file"}\n'
+        '{"decision": "DENY", "descriptor_hash": "bbb", "rule": "tainted_external_side_effect", '
+        '"source_channel": "web", "taint": true, "timestamp": "2026-01-01T00:01:00+00:00", "tool": "send_email"}\n'
+        '{"decision": "ABSENT", "descriptor_hash": "", "rule": "tool_not_allowlisted", '
+        '"source_channel": "cli", "taint": false, "timestamp": "2026-01-01T00:02:00+00:00", "tool": "dangerous_exec"}\n'
+        '{"decision": "SIMULATE", "descriptor_hash": "ccc", "rule": "simulate_external_action", '
+        '"source_channel": "cli", "taint": false, "timestamp": "2026-01-01T00:03:00+00:00", "tool": "send_email"}\n'
+    )
+
+    def _make_base_dir(self, with_audit_content=""):
+        tmp = Path(tempfile.mkdtemp())
+        (tmp / "world_manifest.yaml").write_text(textwrap.dedent("""\
+            world_id: default
+            allowed_tools: [read_file, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              send_email: {allowed: true}
+            taint_rules: []
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+        config_dir = tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text(
+            "simulation:\n  external_side_effects: true\n", encoding="utf-8"
+        )
+        logs_dir = tmp / "safe_mcp_proxy" / "logs"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "audit.jsonl").write_text(with_audit_content, encoding="utf-8")
+        seeds_dir = tmp / "seeds"
+        seeds_dir.mkdir()
+        (seeds_dir / "demo.jsonl").write_text(self.SEED_CONTENT, encoding="utf-8")
+        return tmp
+
+    def _request(self, app, method, path, **kwargs):
+        async def _run():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.request(method, path, **kwargs)
+        return asyncio.run(_run())
+
+    def test_seeds_loaded_when_audit_is_empty(self):
+        tmp = self._make_base_dir(with_audit_content="")
+        try:
+            app = create_app(tmp)
+            response = self._request(app, "GET", "/traces?limit=10")
+            self.assertEqual(response.status_code, 200)
+            traces = response.json()["traces"]
+            decisions = {t["decision"] for t in traces}
+            self.assertEqual(decisions, {"ALLOW", "DENY", "ABSENT", "SIMULATE"})
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_seeds_not_loaded_when_audit_has_data(self):
+        existing = (
+            '{"decision": "ALLOW", "descriptor_hash": "x", "rule": "default_allow", '
+            '"source_channel": "cli", "taint": false, "timestamp": "2026-01-01T00:00:00+00:00", "tool": "read_file"}\n'
+        )
+        tmp = self._make_base_dir(with_audit_content=existing)
+        try:
+            app = create_app(tmp)
+            response = self._request(app, "GET", "/traces?limit=10")
+            self.assertEqual(response.status_code, 200)
+            traces = response.json()["traces"]
+            self.assertEqual(len(traces), 1)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,5 +232,73 @@ class FastAPITests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class TestExportBundle(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "world_manifest.yaml").write_text(textwrap.dedent("""\
+            world_id: default
+            allowed_tools: [read_file, list_repo, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: true}
+              send_email: {allowed: true}
+              dangerous_exec: {allowed: false}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text(
+            "simulation:\n  external_side_effects: true\n", encoding="utf-8"
+        )
+        logs_dir = self.tmp / "safe_mcp_proxy" / "logs"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "audit.jsonl").write_text("", encoding="utf-8")
+        self.app = create_app(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _request(self, method, path, **kwargs):
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.request(method, path, **kwargs)
+        return asyncio.run(_run())
+
+    def test_export_bundle_returns_valid_structure(self):
+        response = self._request("GET", "/export/bundle?scenario=benign_flow")
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["schema_version"], 1)
+        self.assertIn("generated_at", body)
+        self.assertIn("scenario", body)
+        self.assertIn("manifest", body)
+        self.assertIn("traces", body)
+        self.assertEqual(body["scenario"]["name"], "benign_flow")
+        self.assertIn("allowlist", body["manifest"])
+        self.assertIn("capability_map", body["manifest"])
+
+    def test_export_bundle_unknown_scenario_returns_404(self):
+        response = self._request("GET", "/export/bundle?scenario=no_such_scenario")
+        self.assertEqual(response.status_code, 404)
+
+    def test_export_bundle_with_trace_id(self):
+        # First run a scenario to generate a trace
+        run_response = self._request("POST", "/scenarios/benign_flow/run")
+        self.assertEqual(run_response.status_code, 200)
+        trace_id = run_response.json()["trace_id"]
+        self.assertIsNotNone(trace_id)
+
+        response = self._request(
+            "GET", f"/export/bundle?scenario=benign_flow&trace_id={trace_id}"
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body["traces"]), 1)
+        self.assertEqual(body["traces"][0]["id"], trace_id)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_demo.py
+++ b/tests/test_run_demo.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+import unittest
+
+
+class TestRunDemo(unittest.TestCase):
+    def test_wait_ready_returns_false_on_closed_port(self):
+        import run_demo
+        # Port 19999 should not be listening; must time out quickly.
+        ready = run_demo._wait_ready("http://127.0.0.1:19999", timeout=0.5)
+        self.assertFalse(ready)
+
+    def test_ensure_uvicorn_is_noop_when_installed(self):
+        import run_demo
+        # uvicorn is already installed; should not raise.
+        run_demo._ensure_uvicorn()
+
+    def test_script_help_exits_cleanly(self):
+        result = subprocess.run(
+            [sys.executable, "run_demo.py", "--help"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("--port", result.stdout)

--- a/ui/index.html
+++ b/ui/index.html
@@ -441,6 +441,20 @@
     .rule-explain-link a:hover { text-decoration: underline; }
 
     #empty-msg { color: #6e7681; padding: 20px 10px; text-align: center; font-size: 12px; }
+
+    .export-btn {
+      background: transparent;
+      color: #58a6ff;
+      border: 1px solid #1f4d7a;
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-family: inherit;
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+    .export-btn:hover { background: #1a3a5c; }
+    .export-btn:disabled { opacity: 0.4; cursor: default; }
   </style>
 </head>
 <body>
@@ -482,6 +496,8 @@
     <div id="panel-tabs">
       <button class="panel-tab active" data-panel="detail">Detail</button>
       <button class="panel-tab" data-panel="compare">World Diff</button>
+      <button id="export-btn" class="export-btn" style="margin-left:auto" disabled>Export JSON</button>
+      <button id="bundle-btn" class="export-btn" style="margin-left:6px" disabled>Download Bundle</button>
     </div>
     <div id="detail-view">
       <p class="placeholder" id="detail-placeholder">Select a trace to see details.</p>
@@ -527,6 +543,8 @@
 
   let traces = [];
   let selectedId = null;
+  let lastRunScenario = null;
+  let lastRunTraceId  = null;
 
   // ── Decision semantics ───────────────────────────────────
   const DECISION_SEMANTICS = {
@@ -641,6 +659,7 @@
   function renderList() {
     if (!traces.length) {
       tbody.innerHTML = '<tr><td colspan="4" id="empty-msg">No traces yet.</td></tr>';
+      document.getElementById('export-btn').disabled = true;
       return;
     }
     // Show newest first
@@ -746,8 +765,40 @@
 
     detailPH.style.display = 'none';
     detailDiv.style.display = 'block';
+    document.getElementById('export-btn').disabled = false;
     renderDetail(trace);
   }
+
+  // ── Export ────────────────────────────────────────────────
+  function exportCurrentTrace() {
+    const trace = traces.find(t => t.id === selectedId);
+    if (!trace) return;
+    const blob = new Blob([JSON.stringify(trace, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `trace-${trace.id}-${trace.tool_requested}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+  document.getElementById('export-btn').addEventListener('click', exportCurrentTrace);
+
+  async function downloadBundle() {
+    if (!lastRunScenario) return;
+    const params = new URLSearchParams({ scenario: lastRunScenario });
+    if (lastRunTraceId != null) params.set('trace_id', lastRunTraceId);
+    const res = await fetch(`/export/bundle?${params}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `bundle-${lastRunScenario}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+  document.getElementById('bundle-btn').addEventListener('click', downloadBundle);
 
   // ── Fetch & poll ──────────────────────────────────────────
   async function fetchTraces() {
@@ -787,6 +838,9 @@
       const data = await res.json();
       await fetchTraces();
       if (data.trace_id != null) selectTrace(data.trace_id);
+      lastRunScenario = name;
+      lastRunTraceId  = data.trace_id ?? null;
+      document.getElementById('bundle-btn').disabled = false;
     } catch (err) {
       statusEl.textContent = `error: ${err.message}`;
       statusEl.className = 'error';


### PR DESCRIPTION
DS5.1: adds Export JSON button to the detail panel tab bar. Clicking it downloads the currently selected trace as `trace-{id}-{tool}.json` using a client-side Blob, no new API surface needed.

DS5.2: adds shareable demo bundle support — `GET /export/bundle?scenario=<name>&trace_id=<id>` returns a self-contained JSON bundle (schema_version, scenario definition, compiled world manifest, traces). A new `bundle_replay.py` CLI module replays policy decisions from a saved bundle offline (`python -m safe_mcp_proxy.bundle_replay bundle.json`). A Download Bundle button in the UI is enabled after any scenario run and fetches the bundle for that run.

Three new tests cover the bundle endpoint: valid structure, 404 on unknown scenario, and trace_id pinning.

https://claude.ai/code/session_014U8ErpCmzHqMeFmExEnsC6