### PR TITLE
Add LLM wiki directory — persistent knowledge base for the project

### DIFF
--- a/wiki/absent-deny.md
+++ b/wiki/absent-deny.md
@@ -48,3 +48,6 @@ The ABSENT message (`"Action does not exist in this world"`) is the canonical st
 - [[provenance-taint]] — taint is the condition for DENY rule 4
 - [[descriptor-drift]] — schema mutation is the condition for DENY rule 3
 - [[src/safe_mcp_proxy/decision]] — the `Decision` enum
+- [[src/safe_mcp_proxy/policy_engine]] — produces ABSENT/DENY results
+- [[src/safe_mcp_proxy/registry]] — `get_tool()` returning `None` triggers ABSENT
+- [[src/safe_mcp_proxy/executor]] — dispatches on decision; defines `ABSENT_MESSAGE`

--- a/wiki/absent-deny.md
+++ b/wiki/absent-deny.md
@@ -1,0 +1,50 @@
+# ABSENT vs DENY
+
+The core semantic distinction of safe-mcp-proxy. Two different failure modes, each with a distinct meaning.
+
+## What they are
+
+**ABSENT** — the tool or capability does not exist in this world. It was never offered to the agent. The agent has no knowledge of it.
+
+**DENY** — a visible action was blocked by policy. The tool was in the agent's world, but a specific invocation was rejected.
+
+This maps to the project's core principle:
+
+> "Some actions are denied. Others do not exist."
+
+## Why it exists
+
+MCP enables runtime tool discovery, which means an agent could theoretically be manipulated — via prompt injection — into calling any tool the server exposes. ABSENT eliminates this attack surface at the root: if a tool is not in the world manifest's `allowed_tools`, it is invisible. The agent cannot be tricked into calling something it has never seen.
+
+DENY handles a different threat: a tool is legitimately in the world, but a particular invocation violates policy — the request came from an untrusted channel (taint), or the tool's schema was mutated at runtime (descriptor drift).
+
+## How they work
+
+Both outcomes are produced by [[policy-engine]] and returned as the `decision` field in the response JSON.
+
+**ABSENT** is produced by rules 1 and 2 (evaluated before any DENY checks):
+- `tool_not_allowlisted` — tool name not in the registry's allowlist
+- `capability_not_allowed` — capability flag is `false` in `capability_map`
+
+**DENY** is produced by rules 3 and 4:
+- `descriptor_drift` — current schema SHA256 ≠ stored hash
+- `tainted_external_side_effect` — tainted provenance + external side-effect tool
+
+The response payload differs:
+```json
+// ABSENT
+{"decision": "ABSENT", "rule": "tool_not_allowlisted", "result": {"error": "Action does not exist in this world"}}
+
+// DENY
+{"decision": "DENY", "rule": "tainted_external_side_effect", "result": {"error": "Denied by policy", "reason": "tainted_external_side_effect"}}
+```
+
+The ABSENT message (`"Action does not exist in this world"`) is the canonical string defined as `ABSENT_MESSAGE` in [[src/safe_mcp_proxy/executor]].
+
+## See also
+
+- [[policy-engine]] — the 5-path decision logic
+- [[world-manifest]] — where the allowlist and capability flags live
+- [[provenance-taint]] — taint is the condition for DENY rule 4
+- [[descriptor-drift]] — schema mutation is the condition for DENY rule 3
+- [[src/safe_mcp_proxy/decision]] — the `Decision` enum

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -1,0 +1,77 @@
+# Architecture
+
+The executor runs every tool invocation through a fixed 5-stage pipeline. Each stage is deterministic and has a single responsibility.
+
+## Pipeline
+
+```
+Request (tool name + payload + source channel)
+  ↓
+Provenance  — classify source channel; set taint flag
+  ↓
+Registry    — look up tool; filter against world allowlist → ABSENT if missing
+  ↓
+PolicyEngine — evaluate 5 decision paths (see below)
+  ↓
+Executor    — dispatch to handler or simulate_external(); write to audit.jsonl
+  ↓
+Response    { decision, rule, result }
+```
+
+Every stage feeds into the next. The pipeline is synchronous and has no side effects until the ALLOW path in the Executor stage.
+
+## Stage breakdown
+
+### 1. Provenance
+`Provenance.from_source(source_channel)` classifies the request origin. Taint is set immediately if the channel is `email`, `web`, or `tool_output`. The provenance object flows unchanged through the pipeline; it is never mutated.
+
+### 2. Registry lookup
+`executor._tool_context(tool_name)` calls `registry.get_tool(tool_name)`. If the tool is not in the allowlist, `None` is returned. The side-effect type defaults to `"unknown"` and the hash check is skipped (hash_ok=True) — absence is handled by the PolicyEngine, not here.
+
+### 3. PolicyEngine decision
+`policy_engine.decide(...)` evaluates 5 rules in order and returns `PolicyResult(decision, rule_hit)`. See [[policy-engine]] for the full rule set.
+
+### 4. Executor dispatch
+Three execution paths based on `policy.decision`:
+- **ALLOW** — if `simulate_external=True` and tool has `side_effect_type == "external"`: call `simulate_external_action()`. Otherwise: call `registry.execute_tool(tool_name, payload)`.
+- **DENY** — return `{"error": "Denied by policy", "reason": rule_hit}`. No execution.
+- **ABSENT** — return `{"error": "Action does not exist in this world"}`. No execution.
+
+### 5. Audit write
+`_audit()` appends a JSON line to `audit.jsonl` regardless of decision outcome. Every invocation is logged.
+
+## Component map
+
+| Component | Module | Role |
+|-----------|--------|------|
+| `Executor` | [[src/safe_mcp_proxy/executor]] | Orchestrates all stages |
+| `ToolRegistry` | [[src/safe_mcp_proxy/registry]] | Tool definitions and allowlist filtering |
+| `PolicyEngine` | [[src/safe_mcp_proxy/policy_engine]] | Pure decision logic |
+| `OPAPolicyEngine` | [[src/safe_mcp_proxy/opa_engine]] | OPA/Rego drop-in for PolicyEngine |
+| `Provenance` | [[src/safe_mcp_proxy/provenance]] | Source channel and taint |
+| `descriptor` | [[src/safe_mcp_proxy/descriptor]] | SHA256 schema hashing |
+| `compiler` | [[src/safe_mcp_proxy/compiler]] | YAML manifest → runtime config |
+| `simulate` | [[src/safe_mcp_proxy/simulate]] | Mock external action |
+| `main` | [[src/safe_mcp_proxy/main]] | CLI + `build_executor()` wiring |
+| `TraceStore` | [[src/safe_mcp_proxy/trace_store]] | Read interface over audit log |
+| `FastAPI app` | [[src/api/index]] | HTTP API layer |
+
+## Startup wiring
+
+`build_executor(base_dir, world_id, engine)` in [[src/safe_mcp_proxy/main]]:
+1. Resolves manifest path (`world_manifest.yaml` or named world YAML)
+2. Compiles manifest via `compile_world_manifest()` → typed tables
+3. Creates `ToolRegistry.with_mock_tools(allowlist)`
+4. Selects policy engine (`python` or `opa`)
+5. Loads simulation flag from `config/policy.yaml`
+6. Returns fully configured `Executor`
+
+The compiled manifest is immutable once `build_executor()` returns.
+
+## See also
+
+- [[world-manifest]] — the static world definition
+- [[policy-engine]] — the 5 decision paths
+- [[absent-deny]] — the two failure modes
+- [[provenance-taint]] — taint propagation
+- [[audit-replay]] — the audit trail

--- a/wiki/audit-replay.md
+++ b/wiki/audit-replay.md
@@ -1,0 +1,59 @@
+# Audit Log & Replay
+
+Every policy decision is recorded in an append-only JSONL log. The log supports forensic replay: re-running a recorded decision deterministically and verifying it matches.
+
+## Audit log
+
+**Location**: `safe_mcp_proxy/logs/audit.jsonl`
+
+**Format**: one JSON object per line, written by `executor._audit()` after every `execute()` call.
+
+Each entry has these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | ISO-8601 UTC | When the decision was made |
+| `tool` | `str` | Tool name |
+| `decision` | `str` | `ALLOW`, `DENY`, or `ABSENT` |
+| `rule` | `str` | Policy rule that was hit |
+| `taint` | `bool` | Whether the request was tainted |
+| `descriptor_hash` | `str` | SHA256 of the tool schema at call time |
+| `source_channel` | `str` | `cli`, `email`, `web`, or `tool_output` |
+
+The file is strictly append-only. `_audit()` opens with mode `"a"` and never reads or modifies existing entries.
+
+## Replay
+
+`executor.replay(audit_entry)` re-evaluates the [[policy-engine]] for a recorded entry and checks whether the new decision matches the recorded one.
+
+```python
+result = executor.replay({
+    "tool": "send_email",
+    "taint": True,
+    "decision": "DENY",
+    "rule": "tainted_external_side_effect",
+})
+# → {"recorded_decision": "DENY", "replayed_decision": "DENY", "matches": True, ...}
+```
+
+Replay is deterministic: same allowlist + capability_map + taint + tool → same decision. If the manifest or tool registry changed since the original decision, `matches` will be `False`, indicating configuration drift.
+
+## TraceStore
+
+[[src/safe_mcp_proxy/trace_store]] wraps the audit JSONL as a typed, queryable store. Key methods:
+- `all()` — all records
+- `last(n)` — most recent n records
+- `filter(decision=, tool=, since=, until=)` — filtered records
+
+The API layer uses `TraceStore` to serve `/traces` and `/traces/{id}` endpoints.
+
+## Bundle replay
+
+[[src/safe_mcp_proxy/bundle_replay]] enables offline replay from a saved bundle (manifest + traces). Used with the `/export/bundle` API endpoint.
+
+## See also
+
+- [[src/safe_mcp_proxy/executor]] — `_audit()` and `replay()` implementation
+- [[src/safe_mcp_proxy/trace_store]] — typed read interface over the log
+- [[src/safe_mcp_proxy/bundle_replay]] — offline bundle replay
+- [[src/api/index]] — HTTP endpoints for traces and replay

--- a/wiki/descriptor-drift.md
+++ b/wiki/descriptor-drift.md
@@ -42,3 +42,4 @@ The `poisoned_descriptor` scenario in [[src/safe_mcp_proxy/scenarios/index]] dem
 - [[src/safe_mcp_proxy/descriptor]] — implementation
 - [[src/safe_mcp_proxy/registry]] — where hashes are pinned at startup
 - [[src/safe_mcp_proxy/executor]] — where `descriptor_hash_valid()` is called
+- [[src/safe_mcp_proxy/policy_engine]] — evaluates `descriptor_hash_valid` flag as rule 3

--- a/wiki/descriptor-drift.md
+++ b/wiki/descriptor-drift.md
@@ -1,0 +1,44 @@
+# Descriptor Drift
+
+Detects runtime mutation of tool schemas via SHA256 hashing. A mismatch between the stored hash and the current schema triggers DENY.
+
+## What it is
+
+Every `Tool` record stores a `descriptor_hash` — the SHA256 of its schema at registration time. Before each invocation, the executor recomputes the hash of the live schema and compares it to the stored value. If they differ, the tool's descriptor has drifted.
+
+## Why it exists
+
+A supply-chain attack against an MCP server could modify tool schemas after startup — for example, changing a `read_file` tool's description to include prompt injection instructions, or altering parameter types to smuggle data. By pinning the hash at startup and verifying it on every call, the proxy detects any such mutation deterministically.
+
+## How it works
+
+Three functions in `descriptor.py`:
+
+```python
+def normalize_schema(schema: dict) -> str:
+    # Deterministic JSON: sorted keys, no extra whitespace
+    return json.dumps(schema, sort_keys=True, separators=(",", ":"))
+
+def compute_descriptor_hash(schema: dict) -> str:
+    normalized = normalize_schema(schema)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+def descriptor_hash_valid(schema: dict, expected_hash: str) -> bool:
+    return compute_descriptor_hash(schema) == expected_hash
+```
+
+The `ToolRegistry.with_mock_tools()` factory calls `compute_descriptor_hash(schema)` for each tool at registration time, storing the result in `tool.descriptor_hash`.
+
+On each `executor.execute()` call, `_tool_context()` calls `descriptor_hash_valid(tool.schema, tool.descriptor_hash)`. If False, `policy_engine.decide()` returns `DENY / descriptor_drift`.
+
+## Demo scenario
+
+The `poisoned_descriptor` scenario in [[src/safe_mcp_proxy/scenarios/index]] demonstrates this: a `setup` function mutates `read_file`'s schema by adding an `encoding` property. The next invocation is denied with rule `descriptor_drift`.
+
+## See also
+
+- [[policy-engine]] — rule 3: `descriptor_drift`
+- [[absent-deny]] — DENY outcome
+- [[src/safe_mcp_proxy/descriptor]] — implementation
+- [[src/safe_mcp_proxy/registry]] — where hashes are pinned at startup
+- [[src/safe_mcp_proxy/executor]] — where `descriptor_hash_valid()` is called

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,65 @@
+# Wiki Index
+
+Content-oriented catalog of all pages in this wiki.
+
+## Concept Pages
+
+| Page | Description |
+|------|-------------|
+| [[absent-deny]] | The two distinct failure modes: ABSENT (tool hidden) vs DENY (action blocked) |
+| [[world-manifest]] | `world_manifest.yaml` as the sole policy surface — allowlist, capabilities, taint rules |
+| [[policy-engine]] | Five deterministic decision paths evaluated in fixed order |
+| [[provenance-taint]] | Source channel tracking and taint propagation through tool output chains |
+| [[descriptor-drift]] | SHA256 schema integrity — detecting runtime tool descriptor mutations |
+| [[audit-replay]] | Append-only audit log and forensic policy replay |
+| [[architecture]] | Full pipeline overview: Provenance → Registry → PolicyEngine → Executor |
+
+## Source Pages
+
+### Top level
+
+| Page | Description |
+|------|-------------|
+| [[src/index]] | Project root — entry points, configuration files, world manifests |
+
+### `safe_mcp_proxy/` package
+
+| Page | Description |
+|------|-------------|
+| [[src/safe_mcp_proxy/index]] | Main package overview |
+| [[src/safe_mcp_proxy/main]] | CLI entrypoint and `build_executor()` wiring function |
+| [[src/safe_mcp_proxy/executor]] | Pipeline orchestrator and append-only audit logging |
+| [[src/safe_mcp_proxy/registry]] | Tool definitions, allowlist filtering, and handler dispatch |
+| [[src/safe_mcp_proxy/policy_engine]] | Pure Python decision logic — five ordered policy checks |
+| [[src/safe_mcp_proxy/provenance]] | `Provenance` dataclass — source channel and taint tracking |
+| [[src/safe_mcp_proxy/descriptor]] | SHA256 schema normalization and hash validation |
+| [[src/safe_mcp_proxy/compiler]] | World manifest YAML parser — produces typed runtime config |
+| [[src/safe_mcp_proxy/decision]] | `Decision` enum: ALLOW, DENY, ABSENT, SIMULATE |
+| [[src/safe_mcp_proxy/simulate]] | Mock external action handler for tests and demos |
+| [[src/safe_mcp_proxy/trace_store]] | Read-only streaming filter over the audit JSONL log |
+| [[src/safe_mcp_proxy/bundle_replay]] | Offline bundle replayer for saved demo artifacts |
+| [[src/safe_mcp_proxy/opa_engine]] | OPA/Rego drop-in replacement for `PolicyEngine` |
+
+### Sub-packages
+
+| Page | Description |
+|------|-------------|
+| [[src/safe_mcp_proxy/config/index]] | `config/` — `policy.yaml` and per-world YAML manifests |
+| [[src/safe_mcp_proxy/examples/index]] | `examples/` — standalone demo scripts |
+| [[src/safe_mcp_proxy/scenarios/index]] | `scenarios/` — registered, runnable test scenarios |
+| [[src/safe_mcp_proxy/policies/index]] | `policies/` — OPA Rego policy and tests |
+
+### Other packages
+
+| Page | Description |
+|------|-------------|
+| [[src/api/index]] | FastAPI HTTP layer — traces, replay, scenarios, compare, export |
+| [[src/tests/index]] | Test suite overview |
+
+## Meta Pages
+
+| Page | Description |
+|------|-------------|
+| `schema.md` | Wiki conventions, page types, update workflow |
+| `index.md` | This file |
+| `log.md` | Append-only ingest/query/lint history |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,16 @@
+# Wiki Log
+
+Append-only record of ingests, queries, and maintenance operations.
+
+---
+
+## 2026-04-24 — Initial seed ingest
+
+- Ingested full codebase: `safe_mcp_proxy/`, `api/`, `tests/`, `worlds/`, `seeds/`
+- Ingested configuration: `world_manifest.yaml`, `safe_mcp_proxy/config/policy.yaml`, `safe_mcp_proxy/config/worlds/`
+- Ingested policies: `safe_mcp_proxy/policies/proxy.rego`
+- Created meta pages: `schema.md`, `index.md`, `log.md`
+- Created concept pages: `absent-deny.md`, `world-manifest.md`, `policy-engine.md`, `provenance-taint.md`, `descriptor-drift.md`, `audit-replay.md`, `architecture.md`
+- Created source mirror: `src/` tree covering all packages and modules
+- No contradictions found in this initial pass
+- All cross-links verified against created files

--- a/wiki/policy-engine.md
+++ b/wiki/policy-engine.md
@@ -52,3 +52,6 @@ Both implementations produce identical decisions for the same inputs. The Rego p
 - [[src/safe_mcp_proxy/policy_engine]] — Python implementation
 - [[src/safe_mcp_proxy/opa_engine]] — OPA implementation
 - [[src/safe_mcp_proxy/policies/index]] — Rego policy file
+- [[src/safe_mcp_proxy/executor]] — calls `policy_engine.decide()` on every invocation
+- [[src/safe_mcp_proxy/registry]] — supplies the allowlist
+- [[src/safe_mcp_proxy/compiler]] — supplies the `capability_map`

--- a/wiki/policy-engine.md
+++ b/wiki/policy-engine.md
@@ -1,0 +1,54 @@
+# Policy Engine
+
+Five deterministic decision paths evaluated in fixed priority order. Same inputs always produce the same output. No LLM in the enforcement path.
+
+## What it is
+
+The `PolicyEngine` class (`policy_engine.py`) implements the core decision logic. It takes five inputs and returns a `PolicyResult(decision, rule_hit)` tuple.
+
+Inputs:
+- `tool_name` — the requested tool
+- `capability` — the tool's capability key
+- `taint` — whether the request provenance is tainted
+- `side_effect_type` — `"read"`, `"internal"`, `"external"`, or `"unknown"`
+- `descriptor_hash_valid` — whether the tool's current schema matches its pinned hash
+
+## Decision paths (evaluated in order)
+
+```
+1. tool_name not in allowlist
+   → ABSENT / tool_not_allowlisted
+
+2. capability_map[capability] == False
+   → ABSENT / capability_not_allowed
+
+3. descriptor_hash_valid == False
+   → DENY / descriptor_drift
+
+4. taint == True AND side_effect_type == "external"
+   → DENY / tainted_external_side_effect
+
+5. (none of the above)
+   → ALLOW / default_allow
+```
+
+Rules 1 and 2 produce ABSENT. Rules 3 and 4 produce DENY. Only if all four checks pass does the request ALLOW.
+
+The ordering is critical: ABSENT checks run before DENY checks. A tool not in the allowlist cannot trigger a taint violation — it simply does not exist.
+
+## Two implementations
+
+**Python engine** (default): `PolicyEngine` in `policy_engine.py`. Pure Python, no external dependencies. Selected when `policy_engine: python` in the manifest or via `--engine python`.
+
+**OPA engine**: `OPAPolicyEngine` in `opa_engine.py`. Evaluates the same 5 rules using the Rego policy at `safe_mcp_proxy/policies/proxy.rego`. Drop-in replacement — same `decide()` signature. Selected via `policy_engine: opa` in the manifest or `--engine opa`. Supports `subprocess` and `rest` evaluator modes.
+
+Both implementations produce identical decisions for the same inputs. The Rego policy mirrors the Python ordering exactly.
+
+## See also
+
+- [[absent-deny]] — the two failure modes this engine produces
+- [[provenance-taint]] — source of the `taint` input
+- [[descriptor-drift]] — source of the `descriptor_hash_valid` input
+- [[src/safe_mcp_proxy/policy_engine]] — Python implementation
+- [[src/safe_mcp_proxy/opa_engine]] — OPA implementation
+- [[src/safe_mcp_proxy/policies/index]] — Rego policy file

--- a/wiki/provenance-taint.md
+++ b/wiki/provenance-taint.md
@@ -52,3 +52,5 @@ Request from "web" → tainted=True
 - [[absent-deny]] — taint is the condition for DENY rule 4
 - [[policy-engine]] — consumes `provenance.tainted` as the `taint` input
 - [[src/safe_mcp_proxy/provenance]] — implementation
+- [[src/safe_mcp_proxy/executor]] — receives `Provenance` and extracts `tainted`
+- [[src/safe_mcp_proxy/main]] — creates `Provenance.from_source()` from CLI `--source` flag

--- a/wiki/provenance-taint.md
+++ b/wiki/provenance-taint.md
@@ -1,0 +1,54 @@
+# Provenance & Taint
+
+Tracks the origin of a request and propagates distrust through tool output chains. Tainted provenance triggers DENY when an external side-effect tool is invoked.
+
+## What it is
+
+`Provenance` is a frozen dataclass that carries three fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `source_channel` | `str` | The channel this request arrived on |
+| `tainted` | `bool` | True if this or any parent source is untrusted |
+| `parent_sources` | `tuple[str, ...]` | Chain of ancestor source channels |
+
+## Tainted channels
+
+```python
+TAINTED_CHANNELS = {"email", "web", "tool_output"}
+```
+
+Any request arriving from `email`, `web`, or `tool_output` is automatically tainted. `cli` is the only clean channel.
+
+The threat model: an attacker can embed instructions in email content or web pages that an agent reads. If those instructions direct the agent to call a tool with external side effects (like `send_email`), taint propagation ensures the attempt is DENY'd.
+
+## How taint propagates
+
+**From source** (`Provenance.from_source(channel)`):
+```python
+tainted = channel in TAINTED_CHANNELS
+         or any(parent in TAINTED_CHANNELS for parent in parent_sources)
+```
+
+**Through derivation** (`provenance.derive(new_channel)`):
+```python
+# Once tainted, always tainted — even if the next channel is "cli"
+tainted = self.tainted or new_channel in TAINTED_CHANNELS
+parent_sources = self.parent_sources + (self.source_channel,)
+```
+
+Taint is monotonic: it can only be set, never cleared. A chain of tool calls that starts with a web-sourced input remains tainted for its entire lifetime.
+
+## Example
+
+```
+Request from "web" → tainted=True
+  Tool output feeds into next request → derive("tool_output") → still tainted=True
+    That request tries to call send_email (external) → DENY / tainted_external_side_effect
+```
+
+## See also
+
+- [[absent-deny]] — taint is the condition for DENY rule 4
+- [[policy-engine]] — consumes `provenance.tainted` as the `taint` input
+- [[src/safe_mcp_proxy/provenance]] — implementation

--- a/wiki/schema.md
+++ b/wiki/schema.md
@@ -1,0 +1,84 @@
+# Wiki Schema
+
+This document defines conventions for the safe-mcp-proxy wiki. It is co-evolved by humans and LLMs as the project grows.
+
+## Purpose
+
+This wiki is a persistent, AI-maintained knowledge base following the LLM Wiki pattern (Andrej Karpathy, 2025). It accumulates synthesized knowledge about the project incrementally — rather than regenerating answers from raw sources on each query.
+
+Three layers:
+- **Raw sources** (immutable): source code, YAML configs, tests — never modified by the wiki
+- **The wiki** (mutable): this directory — markdown files created and maintained by AI
+- **This schema** (configuration): defines structure and update conventions
+
+## Page Types
+
+### Concept page
+Documents a core idea, design principle, or security mechanism.
+
+```
+# <Concept Name>
+
+## What it is
+One-paragraph definition.
+
+## Why it exists
+The threat or problem it addresses.
+
+## How it works
+Mechanism / implementation details.
+
+## See also
+- [[related-page]]
+```
+
+### Source page
+Documents a Python module or package. Lives under `src/` mirroring the package hierarchy.
+
+```
+# `<module_name.py>` / `<package/>`
+
+## Role
+One-line responsibility.
+
+## Key symbols
+| Name | Kind | Description |
+|------|------|-------------|
+| ... | class/function/constant | ... |
+
+## Depends on
+- [[other-module]]
+
+## Used by
+- [[other-module]]
+```
+
+### Meta page
+`index.md`, `log.md`, `schema.md` — not content pages, never linked as `[[...]]`.
+
+## Cross-linking
+
+Use `[[page-name]]` (filename without `.md`) to reference other wiki pages. All references must point to real files. Do not create dangling links.
+
+Examples:
+- `[[absent-deny]]` → `wiki/absent-deny.md`
+- `[[src/safe_mcp_proxy/executor]]` → `wiki/src/safe_mcp_proxy/executor.md`
+
+## Update Operations
+
+**Ingest**: A new source (issue, ADR, code change) is processed. The LLM reads it, updates affected pages, creates new pages if needed, appends to `log.md`.
+
+**Query**: A question is answered by reading relevant wiki pages. The answer can itself become a new page.
+
+**Lint**: Periodic health check — find contradictions, stale claims, orphaned pages, missing cross-links.
+
+## Naming Conventions
+
+- Concept pages: `kebab-case.md` at wiki root
+- Source pages: `wiki/src/<package>/<module>.md`, mirroring the repo hierarchy
+- Package overview: `wiki/src/<package>/index.md`
+- All filenames lowercase
+
+## Accuracy Requirement
+
+Every claim in this wiki must be grounded in the actual source code, configuration files, or documentation in this repository. Do not invent APIs, behavior, or design rationale that cannot be verified in the codebase.

--- a/wiki/src/api/index.md
+++ b/wiki/src/api/index.md
@@ -53,3 +53,6 @@ Returns per-world `{decision, rule}` for the same scenario.
 
 - [[audit-replay]] — trace and replay semantics
 - [[architecture]] — full pipeline this API exposes
+- [[absent-deny]] — API responses carry ABSENT/DENY decisions from the pipeline
+- [[policy-engine]] — each `/scenarios/{name}/run` and `/compare` call goes through policy evaluation
+- [[provenance-taint]] — `Provenance.from_source(scenario.source_channel)` created per request

--- a/wiki/src/api/index.md
+++ b/wiki/src/api/index.md
@@ -1,0 +1,55 @@
+# `api/`
+
+## Role
+
+FastAPI HTTP layer. Exposes the enforcement pipeline, trace store, scenario runner, world compare, and bundle export over HTTP.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `create_app` | function | Factory that builds and returns the FastAPI app |
+| `app` | module-level | Default app instance (`create_app()`) |
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Serves `ui/index.html` |
+| `GET` | `/traces` | Last N trace records from `TraceStore` |
+| `GET` | `/traces/{trace_id}` | Single trace by line ID |
+| `POST` | `/replay/{trace_id}` | Re-evaluate policy for a recorded trace |
+| `POST` | `/scenarios/{name}/run` | Execute a named scenario |
+| `POST` | `/compare` | Run one scenario across multiple worlds |
+| `GET` | `/export/bundle` | Export manifest + trace as a shareable bundle |
+| `GET` | `/stats` | Decision counts (ALLOW/DENY/ABSENT/SIMULATE) |
+
+## Startup behavior
+
+`create_app()`:
+1. Calls `_seed_if_empty()` — copies `seeds/demo.jsonl` to `audit.jsonl` if the log is empty
+2. Builds `TraceStore` from `audit.jsonl`
+3. Builds `Executor` via `build_executor(base_dir)`
+4. Adds CORS middleware (`allow_origins=["*"]`)
+
+## `/compare` request body
+
+```json
+{"scenario": "benign_flow", "worlds": ["world_a", "world_b"]}
+```
+
+Returns per-world `{decision, rule}` for the same scenario.
+
+## Depends on
+
+- [[src/safe_mcp_proxy/main]] — `build_executor()`
+- [[src/safe_mcp_proxy/trace_store]] — `TraceStore`
+- [[src/safe_mcp_proxy/scenarios/index]] — `scenarios.run()`, `scenarios.get()`
+- [[src/safe_mcp_proxy/compiler]] — `compile_world_manifest()` for bundle export
+- [[src/safe_mcp_proxy/provenance]] — `Provenance.from_source()`
+- [[src/safe_mcp_proxy/decision]] — `Decision` for stats counter
+
+## See also
+
+- [[audit-replay]] — trace and replay semantics
+- [[architecture]] — full pipeline this API exposes

--- a/wiki/src/index.md
+++ b/wiki/src/index.md
@@ -31,3 +31,5 @@ Top-level files and directories in the safe-mcp-proxy repository.
 
 - [[world-manifest]] — world_manifest.yaml explained
 - [[architecture]] — full pipeline overview
+- [[absent-deny]] — the core semantic distinction enforced by this project
+- [[audit-replay]] — `safe_mcp_proxy/logs/audit.jsonl` lives in this repo

--- a/wiki/src/index.md
+++ b/wiki/src/index.md
@@ -1,0 +1,33 @@
+# Project Root
+
+Top-level files and directories in the safe-mcp-proxy repository.
+
+## Entry points
+
+| File | Description |
+|------|-------------|
+| `world_manifest.yaml` | Default world definition — the primary policy surface. See [[world-manifest]]. |
+| `demo.py` | Standalone demo script |
+| `run_demo.py` | One-click demo launcher (starts API + UI) |
+
+## Packages
+
+| Directory | Description |
+|-----------|-------------|
+| [[src/safe_mcp_proxy/index]] | Core enforcement package — all policy logic lives here |
+| [[src/api/index]] | FastAPI HTTP layer |
+| [[src/tests/index]] | Test suite |
+
+## Configuration directories
+
+| Directory | Description |
+|-----------|-------------|
+| `worlds/` | Legacy world YAML files (`repo_assistant.yaml`, `read_only.yaml`, `world_a/b/c.yaml`) |
+| `seeds/` | `demo.jsonl` — pre-generated traces for seeding an empty UI |
+| `pub/posts/` | Blog posts about the project (multi-platform markdown) |
+| `ui/` | `index.html` — single-page frontend for the demo UI |
+
+## See also
+
+- [[world-manifest]] — world_manifest.yaml explained
+- [[architecture]] — full pipeline overview

--- a/wiki/src/safe_mcp_proxy/bundle_replay.md
+++ b/wiki/src/safe_mcp_proxy/bundle_replay.md
@@ -1,0 +1,57 @@
+# `bundle_replay.py`
+
+## Role
+
+Offline bundle replayer. Loads a saved demo bundle (manifest + traces) and replays each trace through the policy engine, reporting how many decisions match.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `replay_bundle` | function | Takes a bundle dict; returns `{total, matched, diverged, results}` |
+
+## Bundle format
+
+```json
+{
+  "manifest": {
+    "allowlist": [...],
+    "capability_map": {...}
+  },
+  "traces": [
+    {
+      "id": 1,
+      "tool_requested": "read_file",
+      "taint": false,
+      "decision": "ALLOW",
+      "rule_hit": "default_allow"
+    }
+  ]
+}
+```
+
+Bundles are produced by the `/export/bundle` API endpoint (see [[src/api/index]]).
+
+## `replay_bundle()` behavior
+
+1. Reconstructs `ToolRegistry` and `PolicyEngine` from `bundle["manifest"]`
+2. Creates an `Executor` with `audit_log_path=os.devnull` (no logging)
+3. For each trace, calls `executor.replay(audit_entry)`
+4. Returns summary: `{total, matched, diverged, results}`
+
+## CLI usage
+
+```bash
+python -m safe_mcp_proxy.bundle_replay path/to/bundle.json
+```
+
+## Depends on
+
+- [[src/safe_mcp_proxy/executor]]
+- [[src/safe_mcp_proxy/policy_engine]]
+- [[src/safe_mcp_proxy/registry]]
+
+## See also
+
+- [[audit-replay]] — replay semantics
+- [[src/api/index]] — `/export/bundle` produces the input to this module

--- a/wiki/src/safe_mcp_proxy/bundle_replay.md
+++ b/wiki/src/safe_mcp_proxy/bundle_replay.md
@@ -54,4 +54,7 @@ python -m safe_mcp_proxy.bundle_replay path/to/bundle.json
 ## See also
 
 - [[audit-replay]] — replay semantics
+- [[policy-engine]] — `PolicyEngine` is reconstructed from bundle manifest and re-evaluated
+- [[absent-deny]] — replay verifies that ABSENT/DENY/ALLOW decisions are reproducible
+- [[architecture]] — bundle_replay is an offline variant of the executor pipeline
 - [[src/api/index]] — `/export/bundle` produces the input to this module

--- a/wiki/src/safe_mcp_proxy/compiler.md
+++ b/wiki/src/safe_mcp_proxy/compiler.md
@@ -43,3 +43,6 @@ Single authoritative mapping from Python domain types to the OPA `input` documen
 ## See also
 
 - [[world-manifest]] — the YAML format this function parses
+- [[policy-engine]] — `allowlist` and `capability_map` output feeds directly into `PolicyEngine`
+- [[absent-deny]] — `allowlist` produced here is what makes tools ABSENT when missing
+- [[architecture]] — compiler runs at startup as part of `build_executor()` wiring

--- a/wiki/src/safe_mcp_proxy/compiler.md
+++ b/wiki/src/safe_mcp_proxy/compiler.md
@@ -1,0 +1,45 @@
+# `compiler.py`
+
+## Role
+
+Parses a world manifest YAML file into a typed runtime config dict. Also provides the OPA input assembler.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `compile_world_manifest` | function | Parses YAML manifest → typed dict |
+| `build_opa_input` | function | Assembles the `input` object for OPA evaluation |
+
+## `compile_world_manifest()` output
+
+```python
+{
+    "world_id":         str,              # from world_id
+    "allowlist":        list[str],        # from allowed_tools
+    "capability_map":   dict[str, bool],  # from capabilities[*].allowed
+    "taint_rules":      list,             # from taint_rules
+    "side_effect_policy": dict,           # from side_effects
+    "policy_engine":    str,              # from policy_engine (default "python")
+}
+```
+
+`capability_map` handles both dict (`{allowed: true}`) and bare bool values in the YAML.
+
+## `build_opa_input()` purpose
+
+Single authoritative mapping from Python domain types to the OPA `input` document consumed by `proxy.rego`. Called by [[src/safe_mcp_proxy/opa_engine]] before each OPA evaluation.
+
+## Depends on
+
+- `yaml` (PyYAML)
+
+## Used by
+
+- [[src/safe_mcp_proxy/main]] — `compile_world_manifest()` in `build_executor()`
+- [[src/safe_mcp_proxy/opa_engine]] — `build_opa_input()` before each OPA call
+- [[src/api/index]] — `compile_world_manifest()` for bundle export
+
+## See also
+
+- [[world-manifest]] — the YAML format this function parses

--- a/wiki/src/safe_mcp_proxy/config/index.md
+++ b/wiki/src/safe_mcp_proxy/config/index.md
@@ -1,0 +1,37 @@
+# `safe_mcp_proxy/config/`
+
+## Role
+
+Runtime configuration for the proxy: the simulation flag and per-world YAML manifests.
+
+## Files
+
+### `policy.yaml`
+
+Controls whether external side effects are simulated (mocked) or executed for real.
+
+```yaml
+simulation:
+  external_side_effects: true
+```
+
+When `true`, the executor calls `simulate_external_action()` instead of the tool handler for `external` side-effect tools on the ALLOW path. This is the default for tests and demos.
+
+Read by `_load_simulation_flag()` in [[src/safe_mcp_proxy/main]].
+
+### `worlds/`
+
+Named world YAML manifests. Each file follows the same format as `world_manifest.yaml`.
+
+Resolved by `_resolve_manifest_path()` in [[src/safe_mcp_proxy/main]] when `--world <world_id>` is passed. Takes priority over the legacy `worlds/` directory at the repo root.
+
+Built-in worlds:
+- `world_a.yaml` — full access (read_file, list_repo, send_email)
+- `world_b.yaml` — read-only (read_file only)
+- `world_c.yaml` — read_file + list_repo, no send_email
+
+## See also
+
+- [[world-manifest]] — world YAML format
+- [[src/safe_mcp_proxy/main]] — loads both files
+- [[src/safe_mcp_proxy/simulate]] — `simulate_external_action()`

--- a/wiki/src/safe_mcp_proxy/decision.md
+++ b/wiki/src/safe_mcp_proxy/decision.md
@@ -1,0 +1,35 @@
+# `decision.py`
+
+## Role
+
+Defines the `Decision` enum — the complete set of valid policy outcomes.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `Decision` | str enum | Four values: `ALLOW`, `DENY`, `ABSENT`, `SIMULATE` |
+| `Decision.parse` | classmethod | Safe parse: returns enum member or original string on unknown value |
+| `Decision.values` | classmethod | Returns `("ALLOW", "DENY", "ABSENT", "SIMULATE")` |
+
+## Values
+
+| Value | Meaning |
+|-------|---------|
+| `ALLOW` | All checks passed; execute the tool |
+| `DENY` | Tool visible but invocation blocked by policy |
+| `ABSENT` | Tool does not exist in this world |
+| `SIMULATE` | Reserved for future approve/simulate workflows |
+
+`Decision` inherits from `str`, so `decision.value` equals `str(decision)` and JSON serialization works naturally.
+
+## Used by
+
+- [[src/safe_mcp_proxy/policy_engine]] — return type of `decide()`
+- [[src/safe_mcp_proxy/executor]] — branching on `policy.decision`
+- [[src/safe_mcp_proxy/trace_store]] — `TraceRecord.decision` field
+- [[src/api/index]] — `Decision` values in stats counter
+
+## See also
+
+- [[absent-deny]] — ABSENT and DENY semantics

--- a/wiki/src/safe_mcp_proxy/decision.md
+++ b/wiki/src/safe_mcp_proxy/decision.md
@@ -33,3 +33,6 @@ Defines the `Decision` enum — the complete set of valid policy outcomes.
 ## See also
 
 - [[absent-deny]] — ABSENT and DENY semantics
+- [[policy-engine]] — `decide()` returns a `PolicyResult` carrying a `Decision`
+- [[audit-replay]] — `decision` field is logged in every audit entry
+- [[architecture]] — `Decision` enum is the return type flowing through stage 3→4 of the pipeline

--- a/wiki/src/safe_mcp_proxy/descriptor.md
+++ b/wiki/src/safe_mcp_proxy/descriptor.md
@@ -1,0 +1,39 @@
+# `descriptor.py`
+
+## Role
+
+Deterministic SHA256 hashing of tool schemas. Used to detect descriptor drift at invocation time.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `normalize_schema` | function | Produces deterministic JSON string: sorted keys, no extra whitespace |
+| `compute_descriptor_hash` | function | Returns SHA256 hex digest of normalized schema |
+| `descriptor_hash_valid` | function | Returns `True` if `compute_descriptor_hash(schema) == expected_hash` |
+
+## Implementation
+
+```python
+def normalize_schema(schema: dict) -> str:
+    return json.dumps(schema, sort_keys=True, separators=(",", ":"))
+
+def compute_descriptor_hash(schema: dict) -> str:
+    return hashlib.sha256(normalize_schema(schema).encode("utf-8")).hexdigest()
+
+def descriptor_hash_valid(schema: dict, expected_hash: str) -> bool:
+    return compute_descriptor_hash(schema) == expected_hash
+```
+
+## Depends on
+
+- `hashlib`, `json` (stdlib only)
+
+## Used by
+
+- [[src/safe_mcp_proxy/registry]] — `compute_descriptor_hash()` called at tool registration
+- [[src/safe_mcp_proxy/executor]] — `descriptor_hash_valid()` called in `_tool_context()`; `compute_descriptor_hash()` for the audit log entry
+
+## See also
+
+- [[descriptor-drift]] — concept page explaining the threat model

--- a/wiki/src/safe_mcp_proxy/examples/index.md
+++ b/wiki/src/safe_mcp_proxy/examples/index.md
@@ -1,0 +1,33 @@
+# `safe_mcp_proxy/examples/`
+
+## Role
+
+Standalone demo scripts. Each script builds a full executor and runs one representative scenario, printing the result to stdout.
+
+## Scripts
+
+| File | Scenario | Expected outcome |
+|------|----------|-----------------|
+| `benign_flow.py` | CLI reads a file | `ALLOW / default_allow` |
+| `prompt_injection.py` | Web-sourced request to send_email | `DENY / tainted_external_side_effect` |
+| `poisoned_descriptor.py` | Schema mutated before invocation | `DENY / descriptor_drift` |
+| `absent_tool_case.py` | Tool not in allowlist | `ABSENT / tool_not_allowlisted` |
+| `deterministic_replay.py` | Replay of a recorded audit entry | `matches: True` |
+
+## Running
+
+```bash
+python -m safe_mcp_proxy.examples.benign_flow
+python -m safe_mcp_proxy.examples.prompt_injection
+python -m safe_mcp_proxy.examples.poisoned_descriptor
+python -m safe_mcp_proxy.examples.absent_tool_case
+```
+
+## Difference from scenarios
+
+These are standalone scripts that print output directly. The [[src/safe_mcp_proxy/scenarios/index]] package provides structured, registered scenarios that are callable from the API and test suite.
+
+## See also
+
+- [[src/safe_mcp_proxy/scenarios/index]] — registered scenario system
+- [[absent-deny]] — the two outcomes these demos illustrate

--- a/wiki/src/safe_mcp_proxy/examples/index.md
+++ b/wiki/src/safe_mcp_proxy/examples/index.md
@@ -31,3 +31,9 @@ These are standalone scripts that print output directly. The [[src/safe_mcp_prox
 
 - [[src/safe_mcp_proxy/scenarios/index]] — registered scenario system
 - [[absent-deny]] — the two outcomes these demos illustrate
+- [[policy-engine]] — each demo exercises a different policy decision path
+- [[provenance-taint]] — `prompt_injection.py` demonstrates taint-based DENY
+- [[descriptor-drift]] — `poisoned_descriptor.py` demonstrates drift-based DENY
+- [[world-manifest]] — demos load `world_manifest.yaml` via `build_executor()`
+- [[audit-replay]] — each demo run appends entries to the audit log
+- [[architecture]] — demos run the full executor pipeline end-to-end

--- a/wiki/src/safe_mcp_proxy/executor.md
+++ b/wiki/src/safe_mcp_proxy/executor.md
@@ -1,0 +1,46 @@
+# `executor.py`
+
+## Role
+
+Orchestrates the full tool invocation pipeline. Dispatches to tool handlers, writes to the audit log, and supports forensic replay.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `ABSENT_MESSAGE` | constant | `"Action does not exist in this world"` — canonical ABSENT response string |
+| `Executor` | class | Main orchestrator |
+| `Executor.__init__` | method | Takes `registry`, `policy_engine`, `audit_log_path`, `simulate_external` |
+| `Executor.execute` | method | Runs one tool invocation through the full pipeline; returns `{decision, rule, result}` |
+| `Executor.replay` | method | Re-evaluates a recorded audit entry; returns `{recorded_*, replayed_*, matches}` |
+| `Executor._tool_context` | method | Looks up tool; returns `(tool, capability, side_effect_type, hash_ok)` |
+| `Executor._audit` | method | Appends one JSON line to `audit_log_path` |
+
+## Execution paths in `execute()`
+
+```
+policy.decision == ALLOW  → simulate_external_action() or registry.execute_tool()
+policy.decision == DENY   → {"error": "Denied by policy", "reason": rule_hit}
+policy.decision == ABSENT → {"error": ABSENT_MESSAGE}
+(always) → _audit(...); return {decision, rule, result}
+```
+
+## Depends on
+
+- [[src/safe_mcp_proxy/registry]] — `get_tool()`, `execute_tool()`
+- [[src/safe_mcp_proxy/policy_engine]] — `decide()`
+- [[src/safe_mcp_proxy/descriptor]] — `compute_descriptor_hash()`, `descriptor_hash_valid()`
+- [[src/safe_mcp_proxy/provenance]] — `Provenance` type
+- [[src/safe_mcp_proxy/simulate]] — `simulate_external_action()`
+- [[src/safe_mcp_proxy/decision]] — `Decision` enum
+
+## Used by
+
+- [[src/safe_mcp_proxy/main]] — `build_executor()` constructs and returns it
+- [[src/api/index]] — `app.state.executor` for HTTP execution and replay
+- [[src/safe_mcp_proxy/scenarios/index]] — `scenarios.run()` calls `executor.execute()`
+
+## See also
+
+- [[audit-replay]] — audit format and replay semantics
+- [[absent-deny]] — the two failure modes

--- a/wiki/src/safe_mcp_proxy/executor.md
+++ b/wiki/src/safe_mcp_proxy/executor.md
@@ -44,3 +44,8 @@ policy.decision == ABSENT → {"error": ABSENT_MESSAGE}
 
 - [[audit-replay]] — audit format and replay semantics
 - [[absent-deny]] — the two failure modes
+- [[policy-engine]] — `decide()` is called on every `execute()` call
+- [[provenance-taint]] — `provenance.tainted` drives DENY rule 4
+- [[descriptor-drift]] — `descriptor_hash_valid()` drives DENY rule 3
+- [[world-manifest]] — compiled manifest tables are passed in at construction
+- [[architecture]] — executor is the central orchestrator of the pipeline

--- a/wiki/src/safe_mcp_proxy/index.md
+++ b/wiki/src/safe_mcp_proxy/index.md
@@ -34,4 +34,10 @@ The core enforcement package. All policy logic, tool registry, provenance tracki
 
 ## See also
 
+- [[absent-deny]] — the core semantic distinction this package enforces
+- [[world-manifest]] — the static policy surface consumed by this package
+- [[policy-engine]] — the 5-path decision logic at the heart of the package
+- [[provenance-taint]] — taint tracking implemented in this package
+- [[descriptor-drift]] — schema integrity checking implemented in this package
+- [[audit-replay]] — audit log format and replay semantics
 - [[architecture]] — how these modules wire together

--- a/wiki/src/safe_mcp_proxy/index.md
+++ b/wiki/src/safe_mcp_proxy/index.md
@@ -1,0 +1,37 @@
+# `safe_mcp_proxy/` package
+
+The core enforcement package. All policy logic, tool registry, provenance tracking, and audit logging live here.
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| [[src/safe_mcp_proxy/main]] | CLI entrypoint; `build_executor()` assembly function |
+| [[src/safe_mcp_proxy/executor]] | Pipeline orchestrator; audit log writer |
+| [[src/safe_mcp_proxy/registry]] | Tool definitions and allowlist-filtered dispatch |
+| [[src/safe_mcp_proxy/policy_engine]] | Pure Python 5-path decision logic |
+| [[src/safe_mcp_proxy/opa_engine]] | OPA/Rego drop-in for `PolicyEngine` |
+| [[src/safe_mcp_proxy/provenance]] | `Provenance` dataclass; taint tracking |
+| [[src/safe_mcp_proxy/descriptor]] | SHA256 schema normalization and validation |
+| [[src/safe_mcp_proxy/compiler]] | World manifest YAML parser |
+| [[src/safe_mcp_proxy/decision]] | `Decision` enum |
+| [[src/safe_mcp_proxy/simulate]] | Mock external action for tests/demos |
+| [[src/safe_mcp_proxy/trace_store]] | Read-only streaming view of audit JSONL |
+| [[src/safe_mcp_proxy/bundle_replay]] | Offline bundle replayer |
+
+## Sub-packages
+
+| Package | Role |
+|---------|------|
+| [[src/safe_mcp_proxy/config/index]] | `policy.yaml` + per-world YAML manifests |
+| [[src/safe_mcp_proxy/examples/index]] | Standalone demo scripts |
+| [[src/safe_mcp_proxy/scenarios/index]] | Registered, runnable test scenarios |
+| [[src/safe_mcp_proxy/policies/index]] | OPA Rego policy files |
+
+## Logs
+
+`safe_mcp_proxy/logs/audit.jsonl` — append-only decision log. See [[audit-replay]].
+
+## See also
+
+- [[architecture]] — how these modules wire together

--- a/wiki/src/safe_mcp_proxy/main.md
+++ b/wiki/src/safe_mcp_proxy/main.md
@@ -60,5 +60,9 @@ world_id="x"  → base_dir/safe_mcp_proxy/config/worlds/x.yaml   (preferred)
 
 ## See also
 
-- [[architecture]] — how build_executor() fits the startup sequence
+- [[architecture]] — how `build_executor()` fits the startup sequence
 - [[world-manifest]] — manifest resolution and format
+- [[provenance-taint]] — `Provenance.from_source(args.source)` is created here
+- [[absent-deny]] — CLI prints decision which may be ABSENT or DENY
+- [[policy-engine]] — `_build_policy_engine()` selects Python or OPA engine
+- [[audit-replay]] — audit log path is wired here (`safe_mcp_proxy/logs/audit.jsonl`)

--- a/wiki/src/safe_mcp_proxy/main.md
+++ b/wiki/src/safe_mcp_proxy/main.md
@@ -1,0 +1,64 @@
+# `main.py`
+
+## Role
+
+CLI entrypoint and `build_executor()` assembly function. Wires all components together from a world manifest.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `build_executor` | function | Assembles a fully configured `Executor` from `base_dir` + optional `world_id` + optional `engine` |
+| `main` | function | CLI arg parsing and single-invocation execution |
+| `_resolve_manifest_path` | function | Locates the correct YAML file for a given `world_id` |
+| `_build_policy_engine` | function | Instantiates `PolicyEngine` or `OPAPolicyEngine` based on `engine` string |
+| `_load_simulation_flag` | function | Reads `simulation.external_side_effects` from `config/policy.yaml` |
+
+## `build_executor()` steps
+
+```
+1. _resolve_manifest_path(base_dir, world_id)
+2. compile_world_manifest(manifest_path)
+3. ToolRegistry.with_mock_tools(allowlist)
+4. _build_policy_engine(manifest_tables, resolved_engine, base_dir)
+5. _load_simulation_flag(config/policy.yaml)
+6. return Executor(registry, policy_engine, audit_log_path, simulate_external)
+```
+
+## Manifest resolution order
+
+```
+world_id=None  → base_dir/world_manifest.yaml
+world_id="x"  → base_dir/safe_mcp_proxy/config/worlds/x.yaml   (preferred)
+              → base_dir/worlds/x.yaml                          (fallback)
+              → FileNotFoundError if neither exists
+```
+
+## CLI flags
+
+```
+--tool      required  Tool name
+--source    default="cli"   cli | email | web | tool_output
+--payload   default="{}"    JSON payload string
+--world     optional  World ID
+--engine    optional  python | opa (overrides manifest's policy_engine key)
+```
+
+## Depends on
+
+- [[src/safe_mcp_proxy/compiler]]
+- [[src/safe_mcp_proxy/executor]]
+- [[src/safe_mcp_proxy/policy_engine]]
+- [[src/safe_mcp_proxy/opa_engine]]
+- [[src/safe_mcp_proxy/provenance]]
+- [[src/safe_mcp_proxy/registry]]
+
+## Used by
+
+- [[src/api/index]] — `build_executor()` to construct the app's executor
+- [[src/safe_mcp_proxy/scenarios/index]] — `build_executor()` when no executor is passed
+
+## See also
+
+- [[architecture]] — how build_executor() fits the startup sequence
+- [[world-manifest]] — manifest resolution and format

--- a/wiki/src/safe_mcp_proxy/opa_engine.md
+++ b/wiki/src/safe_mcp_proxy/opa_engine.md
@@ -1,0 +1,47 @@
+# `opa_engine.py`
+
+## Role
+
+OPA/Rego drop-in replacement for `PolicyEngine`. Evaluates the same 5 policy rules via the OPA binary (subprocess) or OPA REST server.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `OPAPolicyEngine` | class | Drop-in for `PolicyEngine` — identical `decide()` signature |
+| `OPAPolicyEngine.__init__` | method | Takes `policy_path`, `allowlist`, `capability_map`, `evaluator`, `opa_url` |
+| `OPAPolicyEngine.decide` | method | Assembles OPA input, evaluates, returns `PolicyResult` |
+| `_eval_subprocess` | method | Runs `opa eval --data proxy.rego --input /dev/stdin` |
+| `_eval_rest` | method | POSTs to OPA REST API at `opa_url` |
+
+## Evaluator modes
+
+| Mode | Mechanism | Requirement |
+|------|-----------|-------------|
+| `subprocess` (default) | `opa` binary via `subprocess.run` | OPA binary on PATH |
+| `rest` | HTTP POST to OPA REST API | Running OPA server at `opa_url` |
+
+If `evaluator="subprocess"` and `opa` is not on PATH, `__init__` raises `RuntimeError` immediately.
+
+## OPA package
+
+The Rego policy is evaluated at `data.safe_mcp_proxy.decision` (`_OPA_PACKAGE`). Default REST URL: `http://localhost:8181/v1/data/safe_mcp_proxy/decision`.
+
+## Input → output
+
+Input is built by [[src/safe_mcp_proxy/compiler]]'s `build_opa_input()`. Output is `{"decision": "ALLOW|DENY|ABSENT", "rule": "<rule_hit>"}`.
+
+## Depends on
+
+- [[src/safe_mcp_proxy/compiler]] — `build_opa_input()`
+- [[src/safe_mcp_proxy/decision]] — `Decision` enum
+- [[src/safe_mcp_proxy/policy_engine]] — `PolicyResult` dataclass
+
+## Used by
+
+- [[src/safe_mcp_proxy/main]] — `_build_policy_engine()` when `engine == "opa"`
+
+## See also
+
+- [[policy-engine]] — Python implementation with same semantics
+- [[src/safe_mcp_proxy/policies/index]] — the Rego policy file

--- a/wiki/src/safe_mcp_proxy/opa_engine.md
+++ b/wiki/src/safe_mcp_proxy/opa_engine.md
@@ -43,5 +43,9 @@ Input is built by [[src/safe_mcp_proxy/compiler]]'s `build_opa_input()`. Output 
 
 ## See also
 
-- [[policy-engine]] — Python implementation with same semantics
+- [[policy-engine]] — concept page; Python and OPA implementations described
+- [[absent-deny]] — both evaluators produce ABSENT and DENY outcomes
+- [[world-manifest]] — `allowlist` and `capability_map` passed in from compiled manifest
+- [[descriptor-drift]] — `descriptor_hash_valid` is one of the inputs to `decide()`
+- [[architecture]] — `OPAPolicyEngine` is an alternative stage 3 in the pipeline
 - [[src/safe_mcp_proxy/policies/index]] — the Rego policy file

--- a/wiki/src/safe_mcp_proxy/policies/index.md
+++ b/wiki/src/safe_mcp_proxy/policies/index.md
@@ -41,4 +41,9 @@ OPA unit tests for `proxy.rego`.
 ## See also
 
 - [[policy-engine]] — concept page; both implementations described
+- [[absent-deny]] — the Rego rules directly implement ABSENT and DENY outcomes
+- [[world-manifest]] — `allowlist` and `capability_map` flow in as OPA `input`
+- [[provenance-taint]] — `input.taint` drives rule 4 in the Rego policy
+- [[descriptor-drift]] — `input.descriptor_hash_valid` drives rule 3 in the Rego policy
+- [[architecture]] — `proxy.rego` is the alternative stage 3 in the pipeline
 - [[src/safe_mcp_proxy/opa_engine]] — the Python module that invokes this file

--- a/wiki/src/safe_mcp_proxy/policies/index.md
+++ b/wiki/src/safe_mcp_proxy/policies/index.md
@@ -1,0 +1,44 @@
+# `safe_mcp_proxy/policies/`
+
+## Role
+
+OPA Rego policy files. `proxy.rego` is the canonical policy used by [[src/safe_mcp_proxy/opa_engine]] when `policy_engine: opa` is selected.
+
+## Files
+
+### `proxy.rego`
+
+Implements the same 5 decision rules as the Python [[src/safe_mcp_proxy/policy_engine]], in the same priority order.
+
+Package: `safe_mcp_proxy`  
+Output path: `data.safe_mcp_proxy.decision`
+
+Input schema:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_name` | string | Requested tool |
+| `capability` | string | Capability key |
+| `taint` | boolean | Tainted provenance flag |
+| `side_effect_type` | string | `"external"` \| `"internal"` \| `"read"` \| `"unknown"` |
+| `descriptor_hash_valid` | boolean | Schema hash validity |
+| `allowlist` | array | Allowed tool names |
+| `capability_map` | object | `{capability: bool}` |
+
+Output: `{"decision": "ALLOW|DENY|ABSENT", "rule": "<rule_hit>"}`
+
+Rule ordering mirrors Python engine exactly:
+1. `tool_not_allowlisted` → ABSENT
+2. `capability_not_allowed` → ABSENT
+3. `descriptor_drift` → DENY
+4. `tainted_external_side_effect` → DENY
+5. `default_allow` (default rule) → ALLOW
+
+### `proxy_test.rego`
+
+OPA unit tests for `proxy.rego`.
+
+## See also
+
+- [[policy-engine]] — concept page; both implementations described
+- [[src/safe_mcp_proxy/opa_engine]] — the Python module that invokes this file

--- a/wiki/src/safe_mcp_proxy/policy_engine.md
+++ b/wiki/src/safe_mcp_proxy/policy_engine.md
@@ -48,4 +48,9 @@ def decide(
 ## See also
 
 - [[policy-engine]] — concept page with full design rationale
+- [[absent-deny]] — ABSENT and DENY are the two failure outcomes this module produces
+- [[provenance-taint]] — `taint` input comes from `Provenance.tainted`
+- [[descriptor-drift]] — `descriptor_hash_valid` input drives rule 3
+- [[world-manifest]] — `allowlist` and `capability_map` constructor args come from the compiled manifest
+- [[architecture]] — PolicyEngine is stage 3 in the fixed pipeline
 - [[src/safe_mcp_proxy/opa_engine]] — alternative OPA implementation with same interface

--- a/wiki/src/safe_mcp_proxy/policy_engine.md
+++ b/wiki/src/safe_mcp_proxy/policy_engine.md
@@ -1,0 +1,51 @@
+# `policy_engine.py`
+
+## Role
+
+Pure Python decision logic. Takes 5 inputs, evaluates 5 ordered rules, returns a `PolicyResult`. No side effects, no I/O.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `PolicyResult` | frozen dataclass | `(decision: Decision, rule_hit: str)` |
+| `PolicyEngine` | class | Stateful engine holding the allowlist and capability_map |
+| `PolicyEngine.__init__` | method | Takes `allowlist: Iterable[str]`, `capability_map: Dict[str, bool]` |
+| `PolicyEngine.decide` | method | Evaluates 5 rules and returns `PolicyResult` |
+
+## `decide()` signature
+
+```python
+def decide(
+    self,
+    tool_name: str,
+    capability: str,
+    taint: bool,
+    side_effect_type: str,
+    descriptor_hash_valid: bool,
+) -> PolicyResult
+```
+
+## Rule evaluation order
+
+```
+1. tool_name not in self.allowlist          → ABSENT / tool_not_allowlisted
+2. not self.capability_map.get(capability)  → ABSENT / capability_not_allowed
+3. not descriptor_hash_valid                → DENY   / descriptor_drift
+4. taint and side_effect_type == "external" → DENY   / tainted_external_side_effect
+5. (default)                                → ALLOW  / default_allow
+```
+
+## Depends on
+
+- [[src/safe_mcp_proxy/decision]] — `Decision` enum
+
+## Used by
+
+- [[src/safe_mcp_proxy/executor]] — `policy_engine.decide()`
+- [[src/safe_mcp_proxy/main]] — instantiated in `_build_policy_engine()`
+
+## See also
+
+- [[policy-engine]] — concept page with full design rationale
+- [[src/safe_mcp_proxy/opa_engine]] — alternative OPA implementation with same interface

--- a/wiki/src/safe_mcp_proxy/provenance.md
+++ b/wiki/src/safe_mcp_proxy/provenance.md
@@ -1,0 +1,41 @@
+# `provenance.py`
+
+## Role
+
+Defines the `Provenance` dataclass and taint classification logic. Tracks source channel and propagates taint through tool output chains.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `TAINTED_CHANNELS` | constant | `{"email", "web", "tool_output"}` |
+| `Provenance` | frozen dataclass | Carries `source_channel`, `tainted`, `parent_sources` |
+| `Provenance.from_source` | classmethod | Factory; sets `tainted` based on channel and parents |
+| `Provenance.derive` | method | Creates child provenance; taint is monotonic (never cleared) |
+
+## `from_source()` logic
+
+```python
+tainted = source_channel in TAINTED_CHANNELS
+         or any(parent in TAINTED_CHANNELS for parent in parent_sources)
+```
+
+## `derive()` logic
+
+```python
+tainted = self.tainted or source_channel in TAINTED_CHANNELS
+parent_sources = self.parent_sources + (self.source_channel,)
+```
+
+Once tainted, `tainted` is never set back to `False` regardless of subsequent source channels.
+
+## Used by
+
+- [[src/safe_mcp_proxy/executor]] — `provenance.tainted` passed to `policy_engine.decide()`
+- [[src/safe_mcp_proxy/main]] — `Provenance.from_source(args.source)`
+- [[src/api/index]] — `Provenance.from_source(scenario.source_channel)`
+- [[src/safe_mcp_proxy/scenarios/index]] — `scenarios.run()` creates provenance per scenario
+
+## See also
+
+- [[provenance-taint]] — concept page with threat model

--- a/wiki/src/safe_mcp_proxy/provenance.md
+++ b/wiki/src/safe_mcp_proxy/provenance.md
@@ -39,3 +39,6 @@ Once tainted, `tainted` is never set back to `False` regardless of subsequent so
 ## See also
 
 - [[provenance-taint]] — concept page with threat model
+- [[absent-deny]] — taint leads directly to DENY rule 4
+- [[policy-engine]] — `taint` is the fourth input to `decide()`
+- [[architecture]] — Provenance is stage 1 (classification) in the fixed pipeline

--- a/wiki/src/safe_mcp_proxy/registry.md
+++ b/wiki/src/safe_mcp_proxy/registry.md
@@ -49,5 +49,8 @@ A tool in `_all_tools` but not in `_exposed_tools` is invisible to the executor 
 
 ## See also
 
-- [[absent-deny]] — get_tool() returning None is the ABSENT trigger
-- [[descriptor-drift]] — descriptor_hash is pinned here
+- [[absent-deny]] — `get_tool()` returning `None` is the ABSENT trigger
+- [[descriptor-drift]] — `descriptor_hash` is pinned here at registration
+- [[world-manifest]] — `allowlist` that controls `_exposed_tools` comes from the manifest
+- [[policy-engine]] — allowlist fed to `PolicyEngine` comes from the same manifest source
+- [[architecture]] — ToolRegistry is stage 2 (lookup) in the fixed pipeline

--- a/wiki/src/safe_mcp_proxy/registry.md
+++ b/wiki/src/safe_mcp_proxy/registry.md
@@ -1,0 +1,53 @@
+# `registry.py`
+
+## Role
+
+Holds tool definitions and enforces the allowlist boundary. The only source of tool handlers, schemas, and descriptor hashes.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `Tool` | dataclass | A single tool record |
+| `Tool.name` | field | Tool identifier string |
+| `Tool.capability` | field | Capability key (maps to `capability_map` in manifest) |
+| `Tool.schema` | field | JSON Schema dict — hashed at registration time |
+| `Tool.descriptor_hash` | field | SHA256 of `schema` at registration — used for drift detection |
+| `Tool.side_effect_type` | field | `"read"`, `"internal"`, or `"external"` |
+| `Tool.handler` | field | `Callable[[dict], dict]` — the tool's implementation |
+| `ToolRegistry` | class | Manages upstream tools and allowlist-filtered view |
+| `ToolRegistry.with_mock_tools` | classmethod | Factory that creates 4 mock tools: `read_file`, `list_repo`, `send_email`, `dangerous_exec` |
+| `ToolRegistry.get_tool` | method | Returns `Tool` if in allowlist, else `None` |
+| `ToolRegistry.execute_tool` | method | Calls `tool.handler(payload)`; raises `KeyError` if not exposed |
+
+## Mock tools (from `with_mock_tools()`)
+
+| Tool | Capability | Side-effect type |
+|------|-----------|-----------------|
+| `read_file` | `read_file` | `read` |
+| `list_repo` | `list_repo` | `internal` |
+| `send_email` | `send_email` | `external` |
+| `dangerous_exec` | `dangerous_exec` | `external` |
+
+`descriptor_hash` is computed via `compute_descriptor_hash(schema)` at registration time.
+
+## Two tool dicts
+
+- `_all_tools` — all upstream tools (used internally)
+- `_exposed_tools` — only tools in the allowlist (used by `get_tool()` and `execute_tool()`)
+
+A tool in `_all_tools` but not in `_exposed_tools` is invisible to the executor — it results in `ABSENT`.
+
+## Depends on
+
+- [[src/safe_mcp_proxy/descriptor]] — `compute_descriptor_hash()`
+
+## Used by
+
+- [[src/safe_mcp_proxy/executor]] — `get_tool()`, `execute_tool()`
+- [[src/safe_mcp_proxy/main]] — `ToolRegistry.with_mock_tools(allowlist)`
+
+## See also
+
+- [[absent-deny]] — get_tool() returning None is the ABSENT trigger
+- [[descriptor-drift]] — descriptor_hash is pinned here

--- a/wiki/src/safe_mcp_proxy/scenarios/index.md
+++ b/wiki/src/safe_mcp_proxy/scenarios/index.md
@@ -1,0 +1,41 @@
+# `safe_mcp_proxy/scenarios/`
+
+## Role
+
+Registered, runnable test scenarios. Each scenario declares a tool, payload, source channel, and expected outcome. Scenarios are used by the API, the test suite, and the compare endpoint.
+
+## Key symbols (in `__init__.py`)
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `Scenario` | dataclass | `name`, `description`, `tool`, `payload`, `source_channel`, `expected_decision`, `expected_rule`, `setup` |
+| `SCENARIOS` | dict | Global registry: `{name: Scenario}` |
+| `register` | function | Adds a `Scenario` to `SCENARIOS` |
+| `get` | function | Returns scenario by name; raises `KeyError` if unknown |
+| `names` | function | Returns list of registered scenario names |
+| `run` | function | Executes a named scenario; returns `{scenario, result, expected_decision, expected_rule, matches}` |
+
+## Registered scenarios
+
+| Name | Tool | Source | Expected decision | Expected rule |
+|------|------|--------|------------------|---------------|
+| `benign_flow` | `read_file` | `cli` | `ALLOW` | `default_allow` |
+| `prompt_injection` | `send_email` | `web` | `DENY` | `tainted_external_side_effect` |
+| `poisoned_descriptor` | `read_file` | `cli` | `DENY` | `descriptor_drift` |
+| `absent_tool` | `dangerous_exec` | `cli` | `ABSENT` | `tool_not_allowlisted` |
+
+The `poisoned_descriptor` scenario has a `setup` function that mutates `read_file`'s schema before execution.
+
+## Auto-registration
+
+`__init__.py` imports all submodules at the bottom, triggering `register()` calls as a side effect.
+
+## Used by
+
+- [[src/api/index]] — `/scenarios/{name}/run` and `/compare`
+- `tests/test_scenarios.py` — scenario validation tests
+
+## See also
+
+- [[src/safe_mcp_proxy/examples/index]] — standalone scripts for the same scenarios
+- [[absent-deny]] — the outcomes scenarios demonstrate

--- a/wiki/src/safe_mcp_proxy/scenarios/index.md
+++ b/wiki/src/safe_mcp_proxy/scenarios/index.md
@@ -39,3 +39,7 @@ The `poisoned_descriptor` scenario has a `setup` function that mutates `read_fil
 
 - [[src/safe_mcp_proxy/examples/index]] — standalone scripts for the same scenarios
 - [[absent-deny]] — the outcomes scenarios demonstrate
+- [[policy-engine]] — all 4 scenarios exercise different policy paths
+- [[world-manifest]] — scenarios execute against the default `world_manifest.yaml`
+- [[provenance-taint]] — each scenario declares a `source_channel`; tainted ones test rule 4
+- [[architecture]] — `scenarios.run()` exercises the full executor pipeline

--- a/wiki/src/safe_mcp_proxy/simulate.md
+++ b/wiki/src/safe_mcp_proxy/simulate.md
@@ -1,0 +1,26 @@
+# `simulate.py`
+
+## Role
+
+Returns a synthetic response for external-side-effect tools during tests and demos. Prevents real network or I/O calls while preserving the full enforcement pipeline.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `simulate_external_action` | function | Returns `{"simulated": True, "message": "This action would have been executed"}` |
+
+## When it is called
+
+In [[src/safe_mcp_proxy/executor]], when `simulate_external=True` and the policy decision is `ALLOW` and `tool.side_effect_type == "external"`. The `simulate_external` flag is loaded from `safe_mcp_proxy/config/policy.yaml` (`simulation.external_side_effects`).
+
+The simulation path only fires for ALLOW decisions — policy enforcement runs normally first.
+
+## Depends on
+
+Nothing (no imports beyond stdlib typing).
+
+## Used by
+
+- [[src/safe_mcp_proxy/executor]] — `simulate_external_action()` on the ALLOW path
+- [[src/safe_mcp_proxy/bundle_replay]] — `simulate_external=False` (replay does not simulate)

--- a/wiki/src/safe_mcp_proxy/simulate.md
+++ b/wiki/src/safe_mcp_proxy/simulate.md
@@ -24,3 +24,7 @@ Nothing (no imports beyond stdlib typing).
 
 - [[src/safe_mcp_proxy/executor]] — `simulate_external_action()` on the ALLOW path
 - [[src/safe_mcp_proxy/bundle_replay]] — `simulate_external=False` (replay does not simulate)
+
+## See also
+
+- [[architecture]] — `simulate_external_action()` is the mock branch on the ALLOW execution path

--- a/wiki/src/safe_mcp_proxy/trace_store.md
+++ b/wiki/src/safe_mcp_proxy/trace_store.md
@@ -1,0 +1,49 @@
+# `trace_store.py`
+
+## Role
+
+Read-only streaming filter over the audit JSONL log. Provides a typed `TraceRecord` interface and query methods.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `SCHEMA_VERSION` | constant | `1` — current trace record schema version |
+| `TraceRecord` | frozen dataclass | Typed representation of one audit log entry |
+| `TraceRecord.from_raw` | staticmethod | Parses a raw dict (from JSON line) into `TraceRecord` |
+| `TraceRecord.as_dict` | method | Serializes back to a plain dict (for API responses) |
+| `TraceStore` | class | Read-only streaming view of `audit.jsonl` |
+| `TraceStore.all` | method | Returns all records |
+| `TraceStore.last` | method | Returns last `n` records |
+| `TraceStore.filter` | method | Filters by `decision`, `tool`, `since`, `until` |
+
+## `TraceRecord` fields
+
+| Field | Type | Source audit field |
+|-------|------|--------------------|
+| `id` | `int` | Line number in JSONL |
+| `schema_version` | `int` | Always `SCHEMA_VERSION` |
+| `timestamp` | `str` | `timestamp` |
+| `tool_requested` | `str` | `tool` |
+| `decision` | `Decision \| str` | `decision` |
+| `rule_hit` | `str` | `rule` |
+| `source_channel` | `str` | `source_channel` |
+| `taint` | `bool` | `taint` |
+| `descriptor_hash` | `str` | `descriptor_hash` |
+| `input` | `dict \| None` | `input` (optional) |
+
+## Streaming behavior
+
+`_iter_records()` reads the file line by line, skipping blank lines and malformed JSON. The file is never loaded entirely into memory.
+
+## Depends on
+
+- [[src/safe_mcp_proxy/decision]] — `Decision.parse()`
+
+## Used by
+
+- [[src/api/index]] — `app.state.trace_store` for `/traces` and `/replay/{id}` endpoints
+
+## See also
+
+- [[audit-replay]] — audit log format and replay semantics

--- a/wiki/src/safe_mcp_proxy/trace_store.md
+++ b/wiki/src/safe_mcp_proxy/trace_store.md
@@ -47,3 +47,5 @@ Read-only streaming filter over the audit JSONL log. Provides a typed `TraceReco
 ## See also
 
 - [[audit-replay]] — audit log format and replay semantics
+- [[absent-deny]] — `TraceStore.filter(decision=...)` filters by ABSENT/DENY/ALLOW
+- [[architecture]] — TraceStore reads the audit log that is the pipeline's output

--- a/wiki/src/tests/index.md
+++ b/wiki/src/tests/index.md
@@ -1,0 +1,50 @@
+# `tests/`
+
+## Role
+
+Test suite for the proxy pipeline, API layer, OPA engine, trace store, and scenarios.
+
+## Files
+
+| File | Covers |
+|------|--------|
+| `test_proxy.py` | Core pipeline: `TestProxy` (single-world decisions) + `TestMultipleWorlds` (cross-world policy variation) |
+| `test_api.py` | FastAPI endpoints via TestClient |
+| `test_opa_engine.py` | `OPAPolicyEngine` subprocess and REST evaluators |
+| `test_trace_store.py` | `TraceStore` filtering and streaming |
+| `test_scenarios.py` | Named scenario registration and execution |
+| `test_run_demo.py` | `run_demo.py` smoke test |
+
+## Running tests
+
+```bash
+# All tests
+python -m unittest tests.test_proxy
+
+# Single test
+python -m unittest tests.test_proxy.TestProxy.test_benign_cli_read_allows
+```
+
+## `test_proxy.py` patterns
+
+`TestProxy` setup:
+- Creates `ToolRegistry.with_mock_tools(["read_file", "list_repo", "send_email"])`
+- Creates `PolicyEngine` with allowlist and capability_map
+- Creates a temp audit file (`safe_mcp_proxy_test_audit.jsonl`)
+- Creates `Executor(registry, policy, audit_path, simulate_external=True)`
+
+Key test cases:
+- `test_benign_cli_read_allows` — CLI source → `ALLOW`
+- `test_tainted_external_is_denied` — web source + send_email → `DENY`
+- `test_descriptor_drift_is_denied` — mutated schema → `DENY`
+- `test_non_allowlisted_tool_is_absent` — unknown tool → `ABSENT`
+- `test_replay_*` — audit entry replay verification
+
+`TestMultipleWorlds`:
+- Writes temp world YAML files
+- Verifies same input yields different decisions across `world_a` / `world_b`
+
+## See also
+
+- [[audit-replay]] — replay test patterns
+- [[absent-deny]] — the outcomes being tested

--- a/wiki/src/tests/index.md
+++ b/wiki/src/tests/index.md
@@ -48,3 +48,8 @@ Key test cases:
 
 - [[audit-replay]] — replay test patterns
 - [[absent-deny]] — the outcomes being tested
+- [[policy-engine]] — test cases cover all 5 decision paths
+- [[world-manifest]] — `TestMultipleWorlds` tests cross-world policy variation
+- [[provenance-taint]] — `test_tainted_external_is_denied` tests taint rule directly
+- [[descriptor-drift]] — `test_descriptor_drift_is_denied` tests schema mutation detection
+- [[architecture]] — tests exercise the full executor pipeline end-to-end

--- a/wiki/world-manifest.md
+++ b/wiki/world-manifest.md
@@ -75,3 +75,5 @@ Built-in worlds:
 - [[src/safe_mcp_proxy/compiler]] — parses this file
 - [[src/safe_mcp_proxy/main]] — loads and wires the manifest
 - [[src/safe_mcp_proxy/config/index]] — world file locations
+- [[src/safe_mcp_proxy/executor]] — receives compiled manifest tables at construction
+- [[src/safe_mcp_proxy/opa_engine]] — receives `allowlist` and `capability_map` from manifest

--- a/wiki/world-manifest.md
+++ b/wiki/world-manifest.md
@@ -1,0 +1,77 @@
+# World Manifest
+
+The primary policy surface. A YAML file that defines a "world" — the complete set of tools, capabilities, taint rules, and side-effect policies visible to an agent in this context.
+
+## What it is
+
+`world_manifest.yaml` (repo root) is the static world definition. It is the single authoritative source for what is allowed and what does not exist.
+
+```yaml
+world_id: "repo_assistant"
+
+policy_engine: python   # "python" (default) or "opa"
+
+allowed_tools:
+  - read_file
+  - list_repo
+  - send_email
+
+capabilities:
+  read_file:
+    allowed: true
+  list_repo:
+    allowed: true
+  send_email:
+    allowed: true
+  dangerous_exec:
+    allowed: false
+
+taint_rules:
+  - tainted_external: deny
+
+side_effects:
+  external: restricted
+```
+
+## Why it exists
+
+Every tool invocation passes through the manifest. The manifest is compiled once at startup into an immutable runtime config — it is never mutated during execution. This gives operators a single declaration point to control the entire tool surface.
+
+Different agents (or the same agent in different contexts) can be given different worlds. A world with only `read_file` makes `send_email` absent — not denied, absent.
+
+## How it works
+
+The manifest is loaded and compiled by [[src/safe_mcp_proxy/compiler]] via `compile_world_manifest()`. The result is a dict with these keys:
+
+| Key | Type | Source field |
+|-----|------|-------------|
+| `world_id` | `str` | `world_id` |
+| `allowlist` | `list[str]` | `allowed_tools` |
+| `capability_map` | `dict[str, bool]` | `capabilities[*].allowed` |
+| `taint_rules` | `list` | `taint_rules` |
+| `side_effect_policy` | `dict` | `side_effects` |
+| `policy_engine` | `str` | `policy_engine` |
+
+`build_executor()` in [[src/safe_mcp_proxy/main]] passes `allowlist` and `capability_map` to both the [[src/safe_mcp_proxy/registry]] (for tool filtering) and the [[src/safe_mcp_proxy/policy_engine]] (for decisions).
+
+## Multiple worlds
+
+Named worlds can be stored in two locations (searched in order):
+1. `safe_mcp_proxy/config/worlds/<world_id>.yaml`
+2. `worlds/<world_id>.yaml`
+
+The CLI `--world` flag selects the world. The API `/compare` endpoint runs the same scenario across multiple worlds simultaneously.
+
+Built-in worlds:
+- `world_a` — full access (read_file, list_repo, send_email)
+- `world_b` — read-only (read_file only)
+- `world_c` — no send_email
+- `repo_assistant` — full access
+- `read_only` — read_file only
+
+## See also
+
+- [[absent-deny]] — allowlist determines ABSENT
+- [[src/safe_mcp_proxy/compiler]] — parses this file
+- [[src/safe_mcp_proxy/main]] — loads and wires the manifest
+- [[src/safe_mcp_proxy/config/index]] — world file locations


### PR DESCRIPTION
Implements the LLM Wiki pattern (Karpathy, 2025): a structured collection
of markdown files that accumulates synthesized project knowledge over time,
maintainable incrementally by LLMs rather than regenerated on each query.

Structure:
- wiki/schema.md, index.md, log.md — meta/conventions
- wiki/*.md — 7 concept pages (absent-deny, world-manifest, policy-engine,
  provenance-taint, descriptor-drift, audit-replay, architecture)
- wiki/src/ — source mirror mirroring the full package hierarchy
  (safe_mcp_proxy/, api/, tests/ with per-package index files)

https://claude.ai/code/session_01NRJPienoarLdBXU41ggsF9