### PR TITLE
Add wiki publishing (mkdocs + Vercel) and wire wiki into CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .codex
+site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,23 @@ Every decision is appended to `safe_mcp_proxy/logs/audit.jsonl` in JSON lines fo
 2. Add the tool name to `allowed_tools` and the capability under `capabilities` in `world_manifest.yaml`.
 3. Add a test in `tests/test_proxy.py` using a temp audit file and `simulate_external=True`.
 
+## Wiki
+
+`wiki/` is a persistent AI-maintained knowledge base (LLM Wiki pattern). Use it as a primary reference for architecture, design decisions, and module behavior — synthesized wiki pages are faster to consume than raw source files.
+
+**When starting work on any non-trivial task**, read `wiki/index.md` first to locate relevant pages, then read those pages before writing code or making design decisions.
+
+**Concept pages by topic:**
+- `wiki/absent-deny.md` — before any policy or decision logic changes
+- `wiki/architecture.md` — before any pipeline changes
+- `wiki/policy-engine.md` — before modifying `policy_engine.py` or `opa_engine.py`
+- `wiki/provenance-taint.md` — before modifying `provenance.py`
+- `wiki/descriptor-drift.md` — before modifying `descriptor.py`
+- `wiki/world-manifest.md` — before modifying world manifests or `compiler.py`
+- `wiki/audit-replay.md` — before modifying `executor.py` or `trace_store.py`
+
+**After making significant changes** (new module, changed behavior, new policy path): update affected wiki pages following `wiki/schema.md` conventions and append an entry to `wiki/log.md`.
+
 ## Roadmap & "What's next?"
 
 When asked **"what's next?"**, **"что дальше?"**, **"next issue"**, **"next task"**, or similar:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: safe-mcp-proxy wiki
+docs_dir: wiki
+theme:
+  name: material
+  palette:
+    scheme: slate
+  features:
+    - navigation.sections
+    - navigation.indexes
+    - content.code.copy

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6
+mkdocs-material>=9.5

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "pip install -r requirements-docs.txt && mkdocs build",
+  "outputDirectory": "site",
+  "installCommand": "pip install -r requirements-docs.txt"
+}

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -63,3 +63,4 @@ Content-oriented catalog of all pages in this wiki.
 | `schema.md` | Wiki conventions, page types, update workflow |
 | `index.md` | This file |
 | `log.md` | Append-only ingest/query/lint history |
+| `publishing.md` | How to build and deploy the wiki as a static site (Vercel, GitHub Pages) |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -4,6 +4,17 @@ Append-only record of ingests, queries, and maintenance operations.
 
 ---
 
+## 2026-04-24 — Publishing infrastructure + Claude Code wiki integration
+
+- Created `mkdocs.yml` — mkdocs-material static site built from `wiki/` directory
+- Created `vercel.json` — Vercel build config (`buildCommand: mkdocs build`, `outputDirectory: site`)
+- Created `requirements-docs.txt` — doc-only dependencies (`mkdocs`, `mkdocs-material`), separate from runtime
+- Created `wiki/publishing.md` — deployment guide (Vercel, GitHub Pages, local preview, wikilinks caveat)
+- Updated `wiki/index.md` — added `publishing.md` to Meta Pages table
+- Updated `CLAUDE.md` — added `## Wiki` section directing Claude to read relevant pages before and after non-trivial tasks
+
+---
+
 ## 2026-04-24 — Initial seed ingest
 
 - Ingested full codebase: `safe_mcp_proxy/`, `api/`, `tests/`, `worlds/`, `seeds/`

--- a/wiki/publishing.md
+++ b/wiki/publishing.md
@@ -1,0 +1,44 @@
+# Publishing
+
+This page explains how to build and deploy the wiki as a static site.
+
+The wiki is built with [mkdocs](https://www.mkdocs.org/) and the [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) theme. Configuration lives in `mkdocs.yml` at the repo root. Doc-only dependencies are in `requirements-docs.txt` — they are separate from the runtime project and not required to run the proxy.
+
+## Local preview
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve
+```
+
+Visit http://localhost:8000. Changes to `wiki/` files are reflected live.
+
+## Deploy to Vercel
+
+1. Connect the repository to a Vercel project.
+2. Leave framework preset as **Other**.
+3. Vercel reads `vercel.json` automatically:
+   - Build command: `pip install -r requirements-docs.txt && mkdocs build`
+   - Output directory: `site`
+4. Deploy. No further configuration needed.
+
+Every push to the tracked branch triggers a new deployment.
+
+## Deploy to GitHub Pages
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs gh-deploy
+```
+
+This builds the site and force-pushes to the `gh-pages` branch. Enable GitHub Pages in repository settings pointing at that branch.
+
+## Known limitation — wikilinks
+
+Wiki pages use `[[page-name]]` cross-reference syntax (Obsidian-style). This syntax is used for AI navigation and is not parsed by mkdocs — it renders as literal text `[[page-name]]` in the published HTML.
+
+The published site is a human-readable reference. AI consumers navigate via the raw markdown files directly.
+
+## Build output
+
+The build writes to `site/` at the repo root. This directory is listed in `.gitignore` and should not be committed.


### PR DESCRIPTION
- mkdocs.yml + requirements-docs.txt: build wiki/ as static site with mkdocs-material
- vercel.json: one-click Vercel deploy (pip install + mkdocs build → site/)
- wiki/publishing.md: deployment guide covering Vercel, GitHub Pages, local preview, and the [[wikilink]] caveat
- CLAUDE.md ## Wiki section: directs Claude to read relevant concept pages before non-trivial tasks and update wiki after significant changes
- .gitignore: exclude site/ build output
- wiki/index.md + wiki/log.md: updated to reflect additions

https://claude.ai/code/session_01KDb2soGLHfSiFLPY2BGxyX