### PR TITLE
chore: prioritize EPIC 9 (Atlassian) in what's-next rule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# safe-mcp-proxy — Atlassian MCP Proxy configuration
+# Copy to .env and fill in your values before running.
+
+# ── Upstream ──────────────────────────────────────────────────────────────────
+# URL of the Atlassian Remote MCP Server (https://mcp.atlassian.com/v1/sse
+# or a self-hosted instance).  Leave empty to run in stub/offline mode.
+ATLASSIAN_MCP_URL=
+
+# ── Mode ──────────────────────────────────────────────────────────────────────
+# proxy  — forward requests to ATLASSIAN_MCP_URL after policy gate
+# stub   — return placeholder responses (no upstream needed; good for testing)
+ATLASSIAN_PROXY_MODE=proxy
+
+# ── Timeout ───────────────────────────────────────────────────────────────────
+# Seconds to wait for a response from the upstream MCP server.
+ATLASSIAN_MCP_TIMEOUT=30
+
+# ── Policy manifest ───────────────────────────────────────────────────────────
+# Absolute path to the YAML manifest that defines allowed tools, arg rules,
+# data-flow rules, and safe abstractions.
+# Default (when unset): manifests/atlassian_mvp.yaml inside the repo.
+ATLASSIAN_MANIFEST_PATH=
+
+# ── Tool allowlist / denylist overrides ───────────────────────────────────────
+# Comma-separated tool names.  These supplement the manifest; the manifest
+# takes precedence for data-flow and arg rules.
+ATLASSIAN_ALLOWED_TOOLS=
+ATLASSIAN_DENIED_TOOLS=
+
+# ── Source channel ────────────────────────────────────────────────────────────
+# Declares the trust level of requests entering the proxy.
+# Tainted channels (email, web, tool_output) trigger write-block rules.
+# cli is the clean/trusted channel.
+ATLASSIAN_SOURCE_CHANNEL=cli
+
+# ── Debug mode ────────────────────────────────────────────────────────────────
+# When true, each tools/call response includes _debug.flow_context showing
+# active data-flow labels.  Never enable in production.
+ATLASSIAN_DEBUG=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,11 +109,11 @@ Every decision is appended to `safe_mcp_proxy/logs/audit.jsonl` in JSON lines fo
 When asked **"what's next?"**, **"что дальше?"**, **"next issue"**, **"next task"**, or similar:
 
 1. Fetch open issues: use `mcp__github__list_issues` with `owner=sv-pro`, `repo=safe-mcp-proxy`, `state=OPEN`.
-2. Pick the highest-priority open issue from the lowest EPIC number.
+2. Pick the highest-priority open issue from the highest EPIC number.
 3. Report the issue number, title, and task list before starting work.
 
 Issues live at: https://github.com/sv-pro/safe-mcp-proxy/issues
 
-- **Open** = work remaining (EPICs 5–7)
-- **Closed** = already implemented (EPICs 0–4)
+- **Open** = work remaining (EPICs 8–9)
+- **Closed** = already implemented (EPICs 0–7)
 - Labels: `epic/N-*`, `type/*`, `priority/*`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Runtime dependencies
+RUN pip install --no-cache-dir pyyaml fastapi uvicorn[standard]
+
+COPY . .
+
+# Create log directory (gitignored at runtime)
+RUN mkdir -p safe_mcp_proxy/logs
+
+EXPOSE 8000
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -255,6 +255,95 @@ Every decision is appended to `safe_mcp_proxy/logs/audit.jsonl` in JSON lines fo
 > **Note:** `safe_mcp_proxy/logs/` is gitignored — the live log is a runtime artifact, not source.
 > The API seeds it automatically from `seeds/demo.jsonl` on first start when the file is absent or empty.
 
+## Atlassian MCP Proxy
+
+A policy-enforcing passthrough for the [Atlassian Remote MCP Server](https://mcp.atlassian.com). It sits between an AI agent and Atlassian tools (Jira, Confluence) and enforces four layers of control on every `tools/call`:
+
+| Layer | What it does |
+|---|---|
+| Allowlist (ABSENT) | Tools not in the manifest are invisible to the agent |
+| Taint gate (DENY) | Requests from untrusted channels cannot call write tools |
+| Data-flow rules (DENY) | Raw Confluence content cannot flow into Jira write calls |
+| Arg rules (DENY) | `jira_create_issue` is restricted to approved project keys |
+
+### Quick setup
+
+```bash
+# 1. Configure
+cp .env.example .env
+#    Set ATLASSIAN_MCP_URL, ATLASSIAN_MANIFEST_PATH, etc.
+
+# 2a. Run with Docker
+docker build -t safe-mcp-proxy .
+docker run --env-file .env -p 8000:8000 safe-mcp-proxy
+
+# 2b. Run locally
+pip install pyyaml fastapi "uvicorn[standard]"
+uvicorn api.main:app --reload
+```
+
+The proxy exposes two endpoints:
+
+```text
+POST /atlassian/mcp     — MCP JSON-RPC passthrough (policy-gated)
+GET  /atlassian/config  — Active config (no secrets)
+```
+
+### Audit log
+
+Every request, policy decision, and response is appended to
+`safe_mcp_proxy/logs/atlassian_requests.jsonl`. Each entry carries a
+`trace_id` (UUID) so request → decision → response entries can be
+correlated:
+
+```jsonl
+{"direction":"request",  "trace_id":"a1b2...", "timestamp":"...", "payload":{...}}
+{"direction":"decision", "trace_id":"a1b2...", "timestamp":"...", "tool":"jira_create_issue", "decision":"DENY", "rule":"no_raw_confluence_to_jira", "tainted":false, "flow_labels":["confluence_raw"]}
+{"direction":"response", "trace_id":"a1b2...", "timestamp":"...", "payload":{...}}
+```
+
+Inspect the audit log with the built-in CLI:
+
+```bash
+# List recent decisions
+python -m safe_mcp_proxy.atlassian.cli list --last 20
+
+# Show only blocked calls
+python -m safe_mcp_proxy.atlassian.cli list --decision DENY
+
+# Show all entries for one trace
+python -m safe_mcp_proxy.atlassian.cli trace --trace-id a1b2c3d4
+```
+
+### Policy manifest
+
+The manifest at `manifests/atlassian_mvp.yaml` is the sole policy surface.
+Set `ATLASSIAN_MANIFEST_PATH` to point to it (or a custom manifest):
+
+```yaml
+allowed_tools:
+  - jira_get_issue
+  - jira_create_issue
+  - confluence_get_page
+
+external_write_tools:
+  - jira_create_issue
+
+arg_rules:
+  jira_create_issue:
+    - arg: project_key
+      allowed_values: [SAFE, TEST, DEMO]
+      rule: jira_create_restricted_projects
+
+data_flow_rules:
+  - if_label: confluence_raw
+    deny_for: [jira_create_issue, jira_update_issue, jira_add_comment]
+    rule: no_raw_confluence_to_jira
+```
+
+See [docs/atlassian-quickstart.md](docs/atlassian-quickstart.md) for a
+guided 5-minute demo of the full attack-and-block scenario.
+
 ## Adding a new tool
 
 1. Add a `ToolRecord` entry to `TOOLS` in `registry.py` — set `name`, `capability`, `schema`, `descriptor_hash` (compute via `descriptor.hash_schema()`), `side_effect_type`, and `handler`.

--- a/api/main.py
+++ b/api/main.py
@@ -233,6 +233,31 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             raise HTTPException(status_code=409, detail=f"Token is already {entry.status}")
         return app.state.executor.reject_approval(token)
 
+    # ------------------------------------------------------------------
+    # Atlassian MCP passthrough (EPIC 9 / M1)
+    # ------------------------------------------------------------------
+
+    from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+    from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+
+    _atlassian_log = resolved_base_dir / "safe_mcp_proxy" / "logs" / "atlassian_requests.jsonl"
+
+    @app.post("/atlassian/mcp")
+    async def atlassian_mcp(request: Any = Body(...)) -> dict:
+        """MCP JSON-RPC passthrough to Atlassian MCP (list_tools / call_tool)."""
+        config = AtlassianProxyConfig.from_env()
+        return MCPPassthrough(config, _atlassian_log).forward(request)
+
+    @app.get("/atlassian/config")
+    async def atlassian_config() -> dict:
+        """Show active Atlassian proxy config (no secrets)."""
+        cfg = AtlassianProxyConfig.from_env()
+        return {
+            "mode": cfg.mode,
+            "upstream_configured": bool(cfg.upstream_url),
+            "timeout": cfg.timeout,
+        }
+
     return app
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -239,6 +239,7 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
 
     from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
     from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+    from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine
 
     _atlassian_log = resolved_base_dir / "safe_mcp_proxy" / "logs" / "atlassian_requests.jsonl"
 
@@ -246,7 +247,8 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     async def atlassian_mcp(request: Any = Body(...)) -> dict:
         """MCP JSON-RPC passthrough to Atlassian MCP (list_tools / call_tool)."""
         config = AtlassianProxyConfig.from_env()
-        return MCPPassthrough(config, _atlassian_log).forward(request)
+        policy = ManifestPolicyEngine.from_yaml(config.manifest_path) if config.manifest_path else None
+        return MCPPassthrough(config, _atlassian_log, policy).forward(request)
 
     @app.get("/atlassian/config")
     async def atlassian_config() -> dict:
@@ -256,6 +258,8 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             "mode": cfg.mode,
             "upstream_configured": bool(cfg.upstream_url),
             "timeout": cfg.timeout,
+            "manifest_configured": cfg.manifest_path is not None,
+            "source_channel": cfg.source_channel,
         }
 
     return app

--- a/docs/atlassian-quickstart.md
+++ b/docs/atlassian-quickstart.md
@@ -1,0 +1,128 @@
+# Atlassian MCP Proxy — 5-minute quickstart
+
+This guide walks through the attack-and-block demo. No real Atlassian
+credentials needed — the proxy runs in stub mode.
+
+## 1. Install dependencies (30 seconds)
+
+```bash
+pip install pyyaml fastapi "uvicorn[standard]"
+```
+
+## 2. Start the proxy (10 seconds)
+
+```bash
+uvicorn api.main:app --reload
+```
+
+The proxy starts at `http://localhost:8000`. Check the active config:
+
+```bash
+curl -s http://localhost:8000/atlassian/config | python -m json.tool
+```
+
+Expected output (stub mode — no upstream required):
+
+```json
+{
+  "mode": "proxy",
+  "upstream_configured": false,
+  "timeout": 30,
+  "manifest_configured": false,
+  "source_channel": "cli"
+}
+```
+
+## 3. See the demo scenarios (3 minutes)
+
+Run the full attack-and-block scenario as a self-contained script:
+
+```bash
+python -m safe_mcp_proxy.examples.atlassian_demo
+```
+
+**PATH A — no proxy:** the agent reads raw Confluence content (with
+credentials in it) and immediately writes it to Jira. No policy gate, no
+block. The output shows `CREDENTIALS LEAKED`.
+
+**PATH B — with proxy:** the same sequence is policy-gated:
+
+1. `confluence_get_page` is allowed — but the response is **truncated to
+   500 characters** (safe abstraction) and the session is tagged
+   `confluence_raw`.
+2. `jira_create_issue` is **DENY** (`no_raw_confluence_to_jira`) because
+   the flow context carries `confluence_raw`.
+
+The output shows `BLOCKED`.
+
+## 4. Call the proxy manually (1 minute)
+
+**Allowed call** — read a Jira issue:
+
+```bash
+curl -s -X POST http://localhost:8000/atlassian/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"jira_get_issue","arguments":{"issue_key":"PROJ-1"}}}' \
+  | python -m json.tool
+```
+
+**Blocked call** — tool not in allowlist (ABSENT):
+
+```bash
+curl -s -X POST http://localhost:8000/atlassian/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+       "params":{"name":"jira_bulk_delete","arguments":{}}}' \
+  | python -m json.tool
+```
+
+Response:
+
+```json
+{
+  "error": {
+    "code": -32601,
+    "message": "Action does not exist in this world: 'jira_bulk_delete'",
+    "data": {"decision": "ABSENT", "rule": "tool_not_allowlisted"}
+  }
+}
+```
+
+## 5. Inspect the audit log
+
+```bash
+# All recent decisions
+python -m safe_mcp_proxy.atlassian.cli list --last 10
+
+# Only blocked calls
+python -m safe_mcp_proxy.atlassian.cli list --decision DENY
+
+# Decision stats
+python -m safe_mcp_proxy.atlassian.cli stats
+
+# Full trace for one request
+python -m safe_mcp_proxy.atlassian.cli trace --trace-id <trace_id>
+```
+
+## Docker
+
+```bash
+cp .env.example .env
+# Edit .env — set ATLASSIAN_MCP_URL for a real upstream, or leave empty for stub mode
+
+docker build -t safe-mcp-proxy .
+docker run --env-file .env -p 8000:8000 safe-mcp-proxy
+```
+
+## Connect a real Atlassian upstream
+
+1. Set `ATLASSIAN_MCP_URL` to your Atlassian Remote MCP Server URL.
+2. Set `ATLASSIAN_MANIFEST_PATH` to an absolute path of your manifest YAML
+   (start with `manifests/atlassian_mvp.yaml` and customize).
+3. Set `ATLASSIAN_SOURCE_CHANNEL=web` if requests come from web/email
+   contexts (enables taint-based write blocking).
+4. Restart the proxy.
+
+All policy enforcement is transparent — the agent sees standard MCP
+JSON-RPC responses, with blocked calls returning a JSON-RPC error.

--- a/manifests/atlassian_mvp.yaml
+++ b/manifests/atlassian_mvp.yaml
@@ -1,30 +1,49 @@
 world_id: atlassian_mvp
 
-# Tools visible to the MCP client — everything else is ABSENT.
+# Tool names sourced from Atlassian Remote MCP Server (mcp.atlassian.com).
+# Everything not listed here is ABSENT — does not exist in this world.
 allowed_tools:
-  - jira_read_issue
-  - jira_create_issue
+  # Jira — read
+  - jira_get_issue
+  - jira_search_issues_using_jql
   - jira_get_transitions
+  - jira_get_project
+  - jira_list_projects
+  # Jira — write (atomic only)
+  - jira_create_issue
+  - jira_update_issue
   - jira_transition_issue
-  - jira_search_issues
-  - confluence_read_page
+  - jira_add_comment
+  - jira_assign_issue
+  # Confluence — read
+  - confluence_get_page
   - confluence_search_pages
+  - confluence_get_space
 
-# Which tools write to external systems (taint + external_write → DENY).
+# Tools that write to external systems: tainted source + any of these → DENY.
 external_write_tools:
   - jira_create_issue
+  - jira_update_issue
   - jira_transition_issue
+  - jira_add_comment
+  - jira_assign_issue
 
-# Argument-based rules: per-tool checks on specific argument values.
-# All listed arg_rules for a tool are evaluated in order; first failure → DENY.
+# Composite / destructive tools are ABSENT (not in allowed_tools above):
+#   jira_bulk_create_issues, jira_delete_issue,
+#   confluence_create_page, confluence_update_page
+
+# Argument-based rules: first failing rule → DENY.
 arg_rules:
   jira_create_issue:
     - arg: project_key
       allowed_values: [SAFE, TEST, DEMO]
       rule: jira_create_restricted_projects
 
-# Simple source → sink flow rules (evaluated via taint flag on source_channel).
-# Tainted source + external_write tool → DENY (unsafe_data_flow).
-# Full provenance propagation is implemented in M5.
+# Flow rules: tainted source + external write → DENY.
 flow_rules:
   tainted_source_blocks_external_write: true
+
+# Safe abstractions: confluence_get_page response is truncated to 500 chars
+# (title + summary) before being returned to the client.
+safe_abstractions:
+  confluence_get_page: confluence_get_page_summary

--- a/manifests/atlassian_mvp.yaml
+++ b/manifests/atlassian_mvp.yaml
@@ -1,0 +1,30 @@
+world_id: atlassian_mvp
+
+# Tools visible to the MCP client — everything else is ABSENT.
+allowed_tools:
+  - jira_read_issue
+  - jira_create_issue
+  - jira_get_transitions
+  - jira_transition_issue
+  - jira_search_issues
+  - confluence_read_page
+  - confluence_search_pages
+
+# Which tools write to external systems (taint + external_write → DENY).
+external_write_tools:
+  - jira_create_issue
+  - jira_transition_issue
+
+# Argument-based rules: per-tool checks on specific argument values.
+# All listed arg_rules for a tool are evaluated in order; first failure → DENY.
+arg_rules:
+  jira_create_issue:
+    - arg: project_key
+      allowed_values: [SAFE, TEST, DEMO]
+      rule: jira_create_restricted_projects
+
+# Simple source → sink flow rules (evaluated via taint flag on source_channel).
+# Tainted source + external_write tool → DENY (unsafe_data_flow).
+# Full provenance propagation is implemented in M5.
+flow_rules:
+  tainted_source_blocks_external_write: true

--- a/manifests/atlassian_mvp.yaml
+++ b/manifests/atlassian_mvp.yaml
@@ -47,3 +47,14 @@ flow_rules:
 # (title + summary) before being returned to the client.
 safe_abstractions:
   confluence_get_page: confluence_get_page_summary
+
+# Data-flow rules (Provenance Lite / M5).
+# After a confluence_get_page call the session carries label=confluence_raw.
+# Raw Confluence content must not flow directly into Jira write tools.
+data_flow_rules:
+  - if_label: confluence_raw
+    deny_for:
+      - jira_create_issue
+      - jira_update_issue
+      - jira_add_comment
+    rule: no_raw_confluence_to_jira

--- a/safe_mcp_proxy/atlassian/adapters.py
+++ b/safe_mcp_proxy/atlassian/adapters.py
@@ -1,0 +1,162 @@
+"""Adapter registry for Atlassian Remote MCP Server tool names.
+
+Tool names are sourced from the Atlassian Remote MCP Server
+(mcp.atlassian.com / atlassian-labs/mcp-atlassian).
+
+Each ToolAdapter describes:
+- service:      "jira" | "confluence"
+- capability:   logical capability group (maps to world_manifest capabilities)
+- side_effect:  "read" | "write"
+- atomic:       False = composite tool (multiple side effects in one call)
+- safe_alias:   name of a safe-abstraction variant, if one is defined
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ToolAdapter:
+    name: str
+    service: str
+    capability: str
+    side_effect: str     # "read" | "write"
+    atomic: bool
+    safe_alias: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Atlassian Remote MCP Server — full tool registry
+# ---------------------------------------------------------------------------
+
+ATLASSIAN_TOOLS: Dict[str, ToolAdapter] = {
+    # ------------------------------------------------------------------
+    # Jira — read
+    # ------------------------------------------------------------------
+    "jira_get_issue": ToolAdapter(
+        "jira_get_issue", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_search_issues_using_jql": ToolAdapter(
+        "jira_search_issues_using_jql", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_get_transitions": ToolAdapter(
+        "jira_get_transitions", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_get_project": ToolAdapter(
+        "jira_get_project", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_list_projects": ToolAdapter(
+        "jira_list_projects", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_get_board": ToolAdapter(
+        "jira_get_board", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_get_sprint": ToolAdapter(
+        "jira_get_sprint", "jira", "jira_read", "read", atomic=True
+    ),
+    "jira_get_user": ToolAdapter(
+        "jira_get_user", "jira", "jira_read", "read", atomic=True
+    ),
+    # ------------------------------------------------------------------
+    # Jira — write (atomic)
+    # ------------------------------------------------------------------
+    "jira_create_issue": ToolAdapter(
+        "jira_create_issue", "jira", "jira_write", "write", atomic=True
+    ),
+    "jira_update_issue": ToolAdapter(
+        "jira_update_issue", "jira", "jira_write", "write", atomic=True
+    ),
+    "jira_transition_issue": ToolAdapter(
+        "jira_transition_issue", "jira", "jira_write", "write", atomic=True
+    ),
+    "jira_add_comment": ToolAdapter(
+        "jira_add_comment", "jira", "jira_write", "write", atomic=True
+    ),
+    "jira_assign_issue": ToolAdapter(
+        "jira_assign_issue", "jira", "jira_write", "write", atomic=True
+    ),
+    # ------------------------------------------------------------------
+    # Jira — composite / destructive (deny-list candidates)
+    # ------------------------------------------------------------------
+    "jira_bulk_create_issues": ToolAdapter(
+        "jira_bulk_create_issues", "jira", "jira_write", "write", atomic=False
+    ),
+    "jira_delete_issue": ToolAdapter(
+        "jira_delete_issue", "jira", "jira_write", "write", atomic=False
+    ),
+    # ------------------------------------------------------------------
+    # Confluence — read
+    # safe_alias: confluence_get_page has a safe abstraction that returns
+    # title + summary only (not raw storage-format content)
+    # ------------------------------------------------------------------
+    "confluence_get_page": ToolAdapter(
+        "confluence_get_page", "confluence", "confluence_read", "read",
+        atomic=True, safe_alias="confluence_get_page_summary",
+    ),
+    "confluence_search_pages": ToolAdapter(
+        "confluence_search_pages", "confluence", "confluence_read", "read", atomic=True
+    ),
+    "confluence_get_space": ToolAdapter(
+        "confluence_get_space", "confluence", "confluence_read", "read", atomic=True
+    ),
+    "confluence_list_spaces": ToolAdapter(
+        "confluence_list_spaces", "confluence", "confluence_read", "read", atomic=True
+    ),
+    # ------------------------------------------------------------------
+    # Confluence — write
+    # ------------------------------------------------------------------
+    "confluence_create_page": ToolAdapter(
+        "confluence_create_page", "confluence", "confluence_write", "write", atomic=True
+    ),
+    "confluence_update_page": ToolAdapter(
+        "confluence_update_page", "confluence", "confluence_write", "write", atomic=True
+    ),
+    "confluence_add_comment": ToolAdapter(
+        "confluence_add_comment", "confluence", "confluence_write", "write", atomic=True
+    ),
+}
+
+# Convenience: non-atomic tools that should appear on deny-lists by default.
+COMPOSITE_TOOLS: List[str] = [
+    name for name, a in ATLASSIAN_TOOLS.items() if not a.atomic
+]
+
+
+# ---------------------------------------------------------------------------
+# Safe-abstraction response transformer
+# ---------------------------------------------------------------------------
+
+def apply_safe_abstraction(tool_name: str, response: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply a safe abstraction to a tools/call response if one is defined.
+
+    Currently: confluence_get_page → strip raw storage body, keep
+    title + summary (first 500 chars of plain text) only.
+    """
+    adapter = ATLASSIAN_TOOLS.get(tool_name)
+    if adapter is None or adapter.safe_alias is None:
+        return response
+
+    result = dict(response)
+    inner = dict(result.get("result", {}))
+    content: List[Dict[str, Any]] = list(inner.get("content", []))
+    inner["content"] = _truncate_text_blocks(content, max_chars=500)
+    inner["_abstraction"] = adapter.safe_alias
+    result["result"] = inner
+    return result
+
+
+def _truncate_text_blocks(
+    content: List[Dict[str, Any]], max_chars: int
+) -> List[Dict[str, Any]]:
+    """Truncate all text content blocks to max_chars characters."""
+    out = []
+    for block in content:
+        if block.get("type") == "text":
+            text = block.get("text", "")
+            block = dict(block)
+            if len(text) > max_chars:
+                block["text"] = text[:max_chars] + "…"
+                block["_truncated"] = True
+        out.append(block)
+    return out

--- a/safe_mcp_proxy/atlassian/cli.py
+++ b/safe_mcp_proxy/atlassian/cli.py
@@ -1,0 +1,106 @@
+"""CLI for inspecting Atlassian MCP proxy traces.
+
+Usage:
+    python -m safe_mcp_proxy.atlassian.cli [command] [options]
+
+Commands:
+    list    List decision entries (default)
+    stats   Show decision counts
+    trace   Show all entries for a specific trace_id
+
+Options:
+    --log PATH       Path to JSONL log (default: safe_mcp_proxy/logs/atlassian_requests.jsonl)
+    --decision D     Filter by decision (ALLOW | DENY | ABSENT)
+    --tool TOOL      Filter by tool name
+    --last N         Show last N decisions
+    --trace-id ID    Show all entries for a trace_id (used with trace command)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .trace_reader import AtlassianTraceReader
+
+
+def _default_log() -> Path:
+    return Path(__file__).resolve().parents[2] / "safe_mcp_proxy" / "logs" / "atlassian_requests.jsonl"
+
+
+def _fmt_decision(d: str) -> str:
+    colours = {"ALLOW": "\033[32m", "DENY": "\033[31m", "ABSENT": "\033[33m"}
+    reset = "\033[0m"
+    return f"{colours.get(d, '')}{d:6}{reset}"
+
+
+def cmd_list(reader: AtlassianTraceReader, args: argparse.Namespace) -> int:
+    entries = reader.filter(
+        decision=args.decision,
+        tool=args.tool,
+        last=args.last,
+    )
+    if not entries:
+        print("No entries found.")
+        return 0
+    for e in entries:
+        labels = f"  labels={e.flow_labels}" if e.flow_labels else ""
+        taint = "  tainted" if e.tainted else ""
+        print(
+            f"[{e.timestamp}]  {_fmt_decision(e.decision or '?')}  "
+            f"tool={e.tool}  rule={e.rule}"
+            f"{taint}{labels}  trace={e.trace_id[:8]}"
+        )
+    return 0
+
+
+def cmd_stats(reader: AtlassianTraceReader, _args: argparse.Namespace) -> int:
+    s = reader.stats()
+    print(f"Total decisions : {s['total']}")
+    for decision, count in sorted(s["counts"].items()):
+        print(f"  {_fmt_decision(decision)} : {count}")
+    return 0
+
+
+def cmd_trace(reader: AtlassianTraceReader, args: argparse.Namespace) -> int:
+    if not args.trace_id:
+        print("Error: --trace-id required for 'trace' command.", file=sys.stderr)
+        return 1
+    entries = reader.by_trace(args.trace_id)
+    if not entries:
+        print(f"No entries found for trace_id={args.trace_id!r}")
+        return 0
+    for e in entries:
+        print(json.dumps(e.as_dict(), indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m safe_mcp_proxy.atlassian.cli",
+        description="Inspect Atlassian MCP proxy traces.",
+    )
+    parser.add_argument("command", nargs="?", default="list",
+                        choices=["list", "stats", "trace"])
+    parser.add_argument("--log", default=None,
+                        help="Path to JSONL log file")
+    parser.add_argument("--decision", default=None,
+                        help="Filter by decision: ALLOW | DENY | ABSENT")
+    parser.add_argument("--tool", default=None,
+                        help="Filter by tool name")
+    parser.add_argument("--last", type=int, default=None,
+                        help="Show last N decisions")
+    parser.add_argument("--trace-id", dest="trace_id", default=None,
+                        help="Trace ID to inspect (for 'trace' command)")
+
+    args = parser.parse_args(argv)
+    log_path = Path(args.log) if args.log else _default_log()
+    reader = AtlassianTraceReader(log_path)
+
+    dispatch = {"list": cmd_list, "stats": cmd_stats, "trace": cmd_trace}
+    return dispatch[args.command](reader, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/safe_mcp_proxy/atlassian/config.py
+++ b/safe_mcp_proxy/atlassian/config.py
@@ -34,6 +34,7 @@ class AtlassianProxyConfig:
     denied_tools: Set[str] = field(default_factory=set)
     manifest_path: Optional[Path] = None
     source_channel: str = "cli"
+    debug: bool = False
 
     @classmethod
     def from_env(cls) -> "AtlassianProxyConfig":
@@ -46,6 +47,7 @@ class AtlassianProxyConfig:
             denied_tools=_parse_tool_set(os.environ.get("ATLASSIAN_DENIED_TOOLS", "")),
             manifest_path=Path(raw_manifest) if raw_manifest else None,
             source_channel=os.environ.get("ATLASSIAN_SOURCE_CHANNEL", "cli"),
+            debug=os.environ.get("ATLASSIAN_DEBUG", "").lower() in ("1", "true", "yes"),
         )
 
     @property

--- a/safe_mcp_proxy/atlassian/config.py
+++ b/safe_mcp_proxy/atlassian/config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class AtlassianProxyConfig:
+    """Runtime config for the Atlassian MCP passthrough.
+
+    mode="proxy"  — requests are forwarded through safe-mcp-proxy (default)
+    mode="direct" — clients connect to Atlassian MCP directly; proxy is bypassed
+    """
+
+    upstream_url: str = ""
+    mode: str = "proxy"
+    timeout: int = 30
+
+    @classmethod
+    def from_env(cls) -> "AtlassianProxyConfig":
+        return cls(
+            upstream_url=os.environ.get("ATLASSIAN_MCP_URL", ""),
+            mode=os.environ.get("ATLASSIAN_PROXY_MODE", "proxy"),
+            timeout=int(os.environ.get("ATLASSIAN_MCP_TIMEOUT", "30")),
+        )
+
+    @property
+    def is_proxy_mode(self) -> bool:
+        return self.mode == "proxy"

--- a/safe_mcp_proxy/atlassian/config.py
+++ b/safe_mcp_proxy/atlassian/config.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Set
+from pathlib import Path
+from typing import Optional, Set
 
 from .filter import CapabilityFilter
 
@@ -21,6 +22,9 @@ class AtlassianProxyConfig:
 
     allowed_tools: empty set → passthrough (all tools visible); non-empty → strict allowlist
     denied_tools:  always hidden regardless of allowlist (composite / unsafe tools)
+
+    manifest_path: path to a world manifest YAML with policy rules; None → no enforcement
+    source_channel: provenance channel for incoming requests ("cli", "web", etc.)
     """
 
     upstream_url: str = ""
@@ -28,15 +32,20 @@ class AtlassianProxyConfig:
     timeout: int = 30
     allowed_tools: Set[str] = field(default_factory=set)
     denied_tools: Set[str] = field(default_factory=set)
+    manifest_path: Optional[Path] = None
+    source_channel: str = "cli"
 
     @classmethod
     def from_env(cls) -> "AtlassianProxyConfig":
+        raw_manifest = os.environ.get("ATLASSIAN_MANIFEST_PATH", "")
         return cls(
             upstream_url=os.environ.get("ATLASSIAN_MCP_URL", ""),
             mode=os.environ.get("ATLASSIAN_PROXY_MODE", "proxy"),
             timeout=int(os.environ.get("ATLASSIAN_MCP_TIMEOUT", "30")),
             allowed_tools=_parse_tool_set(os.environ.get("ATLASSIAN_ALLOWED_TOOLS", "")),
             denied_tools=_parse_tool_set(os.environ.get("ATLASSIAN_DENIED_TOOLS", "")),
+            manifest_path=Path(raw_manifest) if raw_manifest else None,
+            source_channel=os.environ.get("ATLASSIAN_SOURCE_CHANNEL", "cli"),
         )
 
     @property

--- a/safe_mcp_proxy/atlassian/config.py
+++ b/safe_mcp_proxy/atlassian/config.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Set
+
+from .filter import CapabilityFilter
+
+
+def _parse_tool_set(raw: str) -> Set[str]:
+    """Parse a comma-separated tool list from an env var value."""
+    return {t.strip() for t in raw.split(",") if t.strip()}
 
 
 @dataclass
@@ -10,11 +18,16 @@ class AtlassianProxyConfig:
 
     mode="proxy"  — requests are forwarded through safe-mcp-proxy (default)
     mode="direct" — clients connect to Atlassian MCP directly; proxy is bypassed
+
+    allowed_tools: empty set → passthrough (all tools visible); non-empty → strict allowlist
+    denied_tools:  always hidden regardless of allowlist (composite / unsafe tools)
     """
 
     upstream_url: str = ""
     mode: str = "proxy"
     timeout: int = 30
+    allowed_tools: Set[str] = field(default_factory=set)
+    denied_tools: Set[str] = field(default_factory=set)
 
     @classmethod
     def from_env(cls) -> "AtlassianProxyConfig":
@@ -22,8 +35,13 @@ class AtlassianProxyConfig:
             upstream_url=os.environ.get("ATLASSIAN_MCP_URL", ""),
             mode=os.environ.get("ATLASSIAN_PROXY_MODE", "proxy"),
             timeout=int(os.environ.get("ATLASSIAN_MCP_TIMEOUT", "30")),
+            allowed_tools=_parse_tool_set(os.environ.get("ATLASSIAN_ALLOWED_TOOLS", "")),
+            denied_tools=_parse_tool_set(os.environ.get("ATLASSIAN_DENIED_TOOLS", "")),
         )
 
     @property
     def is_proxy_mode(self) -> bool:
         return self.mode == "proxy"
+
+    def capability_filter(self) -> CapabilityFilter:
+        return CapabilityFilter(self.allowed_tools, self.denied_tools)

--- a/safe_mcp_proxy/atlassian/filter.py
+++ b/safe_mcp_proxy/atlassian/filter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+
+class CapabilityFilter:
+    """Filter a tools/list result against an allowlist and deny-list.
+
+    Semantics follow the ABSENT principle:
+    - A tool not in the allowlist does not exist in this world.
+    - A tool in the deny-list is explicitly hidden (composite / unsafe).
+    - If allowed_tools is empty the filter is in passthrough mode (all tools
+      pass through, only deny-list is enforced).
+    """
+
+    def __init__(
+        self,
+        allowed_tools: Set[str],
+        denied_tools: Set[str],
+    ) -> None:
+        self._allowed = allowed_tools
+        self._denied = denied_tools
+
+    # ------------------------------------------------------------------
+
+    def filter_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Return only the tools that are visible in this world."""
+        result = []
+        for tool in tools:
+            name = tool.get("name", "")
+            if name in self._denied:
+                continue
+            if self._allowed and name not in self._allowed:
+                continue
+            result.append(tool)
+        return result
+
+    def apply_to_list_response(self, response: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of a tools/list JSON-RPC response with tools filtered."""
+        result = dict(response)
+        inner = dict(result.get("result", {}))
+        inner["tools"] = self.filter_tools(inner.get("tools", []))
+        result["result"] = inner
+        return result

--- a/safe_mcp_proxy/atlassian/flow.py
+++ b/safe_mcp_proxy/atlassian/flow.py
@@ -1,0 +1,81 @@
+"""Data Flow Control (Provenance Lite) for the Atlassian MCP path.
+
+Tracks which data labels are active in a session and enforces flow rules
+(e.g. confluence_raw must not flow into an external write tool).
+
+Labels assigned per tool output:
+  confluence_raw     — raw confluence_get_page response (not abstracted)
+  confluence_summary — safe-abstracted confluence_get_page response
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Set
+
+
+# Data labels produced by Atlassian tool outputs.
+LABEL_CONFLUENCE_RAW = "confluence_raw"
+LABEL_CONFLUENCE_SUMMARY = "confluence_summary"
+
+# Tools whose output produces a data label.
+_OUTPUT_LABELS: Dict[str, str] = {
+    "confluence_get_page": LABEL_CONFLUENCE_RAW,
+}
+# When the safe abstraction is applied, the label changes to summary.
+_ABSTRACTION_LABEL: Dict[str, str] = {
+    LABEL_CONFLUENCE_RAW: LABEL_CONFLUENCE_SUMMARY,
+}
+
+
+class FlowContext:
+    """Mutable session-level tracker of active data labels.
+
+    Updated after each tools/call response; consulted by the policy engine
+    before the next tools/call to enforce data-flow rules.
+    """
+
+    def __init__(self) -> None:
+        self._labels: Set[str] = set()
+
+    # ------------------------------------------------------------------
+
+    def tag_output(self, tool_name: str, was_abstracted: bool) -> None:
+        """Record the data label produced by a successful tool output."""
+        base_label = _OUTPUT_LABELS.get(tool_name)
+        if base_label is None:
+            return
+        if was_abstracted:
+            label = _ABSTRACTION_LABEL.get(base_label, base_label)
+        else:
+            label = base_label
+        self._labels.add(label)
+
+    def active_labels(self) -> Set[str]:
+        return set(self._labels)
+
+    def has_label(self, label: str) -> bool:
+        return label in self._labels
+
+    def clear(self) -> None:
+        self._labels.clear()
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"active_labels": sorted(self._labels)}
+
+
+@dataclass
+class DataFlowRule:
+    if_label: str
+    deny_for: List[str]
+    rule: str
+
+
+def parse_data_flow_rules(raw: List[Dict[str, Any]]) -> List[DataFlowRule]:
+    return [
+        DataFlowRule(
+            if_label=r["if_label"],
+            deny_for=list(r.get("deny_for", [])),
+            rule=r.get("rule", f"data_flow:{r['if_label']}"),
+        )
+        for r in raw
+    ]

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from .adapters import apply_safe_abstraction
 from .config import AtlassianProxyConfig
 from .policy import ManifestPolicyEngine, PolicyDecision
 from safe_mcp_proxy.provenance import TAINTED_CHANNELS
@@ -60,6 +61,11 @@ class MCPPassthrough:
         # Capability filtering for tools/list
         if method == "tools/list" and "result" in response:
             response = self._config.capability_filter().apply_to_list_response(response)
+
+        # Safe abstraction for tools/call responses
+        if method == "tools/call" and "result" in response:
+            tool_name = (request.get("params") or {}).get("name", "")
+            response = apply_safe_abstraction(tool_name, response)
 
         self._log({"direction": "response", "payload": response})
         return response

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -43,7 +44,8 @@ class MCPPassthrough:
 
     def forward(self, request: Dict[str, Any]) -> Dict[str, Any]:
         method = request.get("method", "")
-        self._log({"direction": "request", "payload": request})
+        trace_id = str(uuid.uuid4())
+        self._log({"direction": "request", "payload": request, "trace_id": trace_id})
 
         # ---- Policy gate (tools/call only) ----------------------------
         if method == "tools/call" and self._policy is not None:
@@ -54,10 +56,10 @@ class MCPPassthrough:
             decision = self._policy.evaluate(
                 tool_name, arguments, tainted, flow_context=self._flow
             )
-            self._log_decision(request, decision)
+            self._log_decision(request, decision, trace_id)
             if decision.decision != "ALLOW":
                 response = _blocked_response(request.get("id"), decision)
-                self._log({"direction": "response", "payload": response})
+                self._log({"direction": "response", "payload": response, "trace_id": trace_id})
                 return response
 
         # ---- Forward --------------------------------------------------
@@ -93,7 +95,7 @@ class MCPPassthrough:
             result["_debug"] = {"flow_context": self._flow.as_dict()}
             response = {**response, "result": result}
 
-        self._log({"direction": "response", "payload": response})
+        self._log({"direction": "response", "payload": response, "trace_id": trace_id})
         return response
 
     # ------------------------------------------------------------------
@@ -149,7 +151,9 @@ class MCPPassthrough:
         with self._log_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry) + "\n")
 
-    def _log_decision(self, request: Dict[str, Any], decision: PolicyDecision) -> None:
+    def _log_decision(
+        self, request: Dict[str, Any], decision: PolicyDecision, trace_id: str
+    ) -> None:
         self._log({
             "direction": "decision",
             "tool": decision.tool,
@@ -158,6 +162,7 @@ class MCPPassthrough:
             "tainted": decision.tainted,
             "request_id": request.get("id"),
             "flow_labels": sorted(self._flow.active_labels()) if self._flow else [],
+            "trace_id": trace_id,
         })
 
 

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -38,6 +38,9 @@ class MCPPassthrough:
             except (urllib.error.URLError, OSError) as exc:
                 response = _error_response(request.get("id"), -32603, str(exc))
 
+        if request.get("method") == "tools/list" and "result" in response:
+            response = self._config.capability_filter().apply_to_list_response(response)
+
         self._log({"direction": "response", "payload": response})
         return response
 

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .config import AtlassianProxyConfig
+
+
+class MCPPassthrough:
+    """Stateless MCP passthrough: forward JSON-RPC requests to an upstream
+    Atlassian MCP server and log every request/response pair."""
+
+    def __init__(
+        self,
+        config: AtlassianProxyConfig,
+        log_path: Optional[Path] = None,
+    ) -> None:
+        self._config = config
+        self._log_path = log_path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def forward(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Forward one MCP JSON-RPC request; return the response dict."""
+        self._log({"direction": "request", "payload": request})
+
+        if not self._config.upstream_url or not self._config.is_proxy_mode:
+            response = self._stub_response(request)
+        else:
+            try:
+                response = self._http_forward(request)
+            except (urllib.error.URLError, OSError) as exc:
+                response = _error_response(request.get("id"), -32603, str(exc))
+
+        self._log({"direction": "response", "payload": response})
+        return response
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _http_forward(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        body = json.dumps(request).encode()
+        req = urllib.request.Request(
+            self._config.upstream_url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._config.timeout) as resp:
+            return json.loads(resp.read())
+
+    def _stub_response(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a minimal valid response when upstream is not configured."""
+        method = request.get("method", "")
+        req_id = request.get("id")
+
+        if method == "tools/list":
+            return {"jsonrpc": "2.0", "id": req_id, "result": {"tools": []}}
+
+        if method == "tools/call":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [{"type": "text", "text": "Upstream not configured"}],
+                    "isError": True,
+                },
+            }
+
+        if method == "initialize":
+            return {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "safe-mcp-proxy/atlassian", "version": "0.1.0"},
+                },
+            }
+
+        return {"jsonrpc": "2.0", "id": req_id, "result": {}}
+
+    def _log(self, entry: Dict[str, Any]) -> None:
+        if self._log_path is None:
+            return
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        entry["timestamp"] = datetime.now(timezone.utc).isoformat()
+        with self._log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _error_response(req_id: Any, code: int, message: str) -> Dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -8,28 +8,47 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from .config import AtlassianProxyConfig
+from .policy import ManifestPolicyEngine, PolicyDecision
+from safe_mcp_proxy.provenance import TAINTED_CHANNELS
 
 
 class MCPPassthrough:
-    """Stateless MCP passthrough: forward JSON-RPC requests to an upstream
-    Atlassian MCP server and log every request/response pair."""
+    """Stateless MCP passthrough: enforce policy then forward JSON-RPC requests
+    to an upstream Atlassian MCP server; log every request/response/decision."""
 
     def __init__(
         self,
         config: AtlassianProxyConfig,
         log_path: Optional[Path] = None,
+        policy: Optional[ManifestPolicyEngine] = None,
     ) -> None:
         self._config = config
         self._log_path = log_path
+        self._policy = policy
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def forward(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        """Forward one MCP JSON-RPC request; return the response dict."""
+        """Enforce policy (if configured) then forward; log everything."""
+        method = request.get("method", "")
         self._log({"direction": "request", "payload": request})
 
+        # Policy enforcement gate (tools/call only)
+        if method == "tools/call" and self._policy is not None:
+            params = request.get("params") or {}
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments") or {}
+            tainted = self._config.source_channel in TAINTED_CHANNELS
+            decision = self._policy.evaluate(tool_name, arguments, tainted)
+            self._log_decision(request, decision)
+            if decision.decision != "ALLOW":
+                response = _blocked_response(request.get("id"), decision)
+                self._log({"direction": "response", "payload": response})
+                return response
+
+        # Forward to upstream or return stub
         if not self._config.upstream_url or not self._config.is_proxy_mode:
             response = self._stub_response(request)
         else:
@@ -38,7 +57,8 @@ class MCPPassthrough:
             except (urllib.error.URLError, OSError) as exc:
                 response = _error_response(request.get("id"), -32603, str(exc))
 
-        if request.get("method") == "tools/list" and "result" in response:
+        # Capability filtering for tools/list
+        if method == "tools/list" and "result" in response:
             response = self._config.capability_filter().apply_to_list_response(response)
 
         self._log({"direction": "response", "payload": response})
@@ -98,6 +118,32 @@ class MCPPassthrough:
         with self._log_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry) + "\n")
 
+    def _log_decision(self, request: Dict[str, Any], decision: PolicyDecision) -> None:
+        self._log({
+            "direction": "decision",
+            "tool": decision.tool,
+            "decision": decision.decision,
+            "rule": decision.rule,
+            "tainted": decision.tainted,
+            "request_id": request.get("id"),
+        })
+
 
 def _error_response(req_id: Any, code: int, message: str) -> Dict[str, Any]:
     return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def _blocked_response(req_id: Any, decision: PolicyDecision) -> Dict[str, Any]:
+    if decision.decision == "ABSENT":
+        message = f"Action does not exist in this world: {decision.tool!r}"
+    else:
+        message = f"Action blocked by policy ({decision.rule}): {decision.tool!r}"
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {
+            "code": -32601,
+            "message": message,
+            "data": {"decision": decision.decision, "rule": decision.rule},
+        },
+    }

--- a/safe_mcp_proxy/atlassian/passthrough.py
+++ b/safe_mcp_proxy/atlassian/passthrough.py
@@ -7,49 +7,60 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from .adapters import apply_safe_abstraction
+from .adapters import apply_safe_abstraction, ATLASSIAN_TOOLS
 from .config import AtlassianProxyConfig
+from .flow import FlowContext
 from .policy import ManifestPolicyEngine, PolicyDecision
 from safe_mcp_proxy.provenance import TAINTED_CHANNELS
 
 
 class MCPPassthrough:
-    """Stateless MCP passthrough: enforce policy then forward JSON-RPC requests
-    to an upstream Atlassian MCP server; log every request/response/decision."""
+    """MCP passthrough with policy enforcement and provenance-lite flow tracking.
+
+    Pipeline for tools/call:
+      1. Policy gate  — ABSENT / DENY / ALLOW
+      2. Forward      — to upstream or stub
+      3. Safe abstraction — truncate raw confluence content
+      4. Tag output   — update FlowContext with data label
+      5. Debug info   — optionally attach flow state to response
+    """
 
     def __init__(
         self,
         config: AtlassianProxyConfig,
         log_path: Optional[Path] = None,
         policy: Optional[ManifestPolicyEngine] = None,
+        flow_context: Optional[FlowContext] = None,
     ) -> None:
         self._config = config
         self._log_path = log_path
         self._policy = policy
+        self._flow = flow_context
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def forward(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        """Enforce policy (if configured) then forward; log everything."""
         method = request.get("method", "")
         self._log({"direction": "request", "payload": request})
 
-        # Policy enforcement gate (tools/call only)
+        # ---- Policy gate (tools/call only) ----------------------------
         if method == "tools/call" and self._policy is not None:
             params = request.get("params") or {}
             tool_name = params.get("name", "")
             arguments = params.get("arguments") or {}
             tainted = self._config.source_channel in TAINTED_CHANNELS
-            decision = self._policy.evaluate(tool_name, arguments, tainted)
+            decision = self._policy.evaluate(
+                tool_name, arguments, tainted, flow_context=self._flow
+            )
             self._log_decision(request, decision)
             if decision.decision != "ALLOW":
                 response = _blocked_response(request.get("id"), decision)
                 self._log({"direction": "response", "payload": response})
                 return response
 
-        # Forward to upstream or return stub
+        # ---- Forward --------------------------------------------------
         if not self._config.upstream_url or not self._config.is_proxy_mode:
             response = self._stub_response(request)
         else:
@@ -58,14 +69,29 @@ class MCPPassthrough:
             except (urllib.error.URLError, OSError) as exc:
                 response = _error_response(request.get("id"), -32603, str(exc))
 
-        # Capability filtering for tools/list
+        # ---- Post-processing for tools/call ---------------------------
+        if method == "tools/call" and "result" in response:
+            params = request.get("params") or {}
+            tool_name = params.get("name", "")
+
+            # Safe abstraction (M4): truncate raw content
+            was_abstracted = ATLASSIAN_TOOLS.get(tool_name) is not None and \
+                ATLASSIAN_TOOLS[tool_name].safe_alias is not None
+            response = apply_safe_abstraction(tool_name, response)
+
+            # Tag output (M5): update flow context
+            if self._flow is not None:
+                self._flow.tag_output(tool_name, was_abstracted=was_abstracted)
+
+        # ---- Capability filtering for tools/list ----------------------
         if method == "tools/list" and "result" in response:
             response = self._config.capability_filter().apply_to_list_response(response)
 
-        # Safe abstraction for tools/call responses
-        if method == "tools/call" and "result" in response:
-            tool_name = (request.get("params") or {}).get("name", "")
-            response = apply_safe_abstraction(tool_name, response)
+        # ---- Debug mode -----------------------------------------------
+        if self._config.debug and self._flow is not None and "result" in response:
+            result = dict(response["result"])
+            result["_debug"] = {"flow_context": self._flow.as_dict()}
+            response = {**response, "result": result}
 
         self._log({"direction": "response", "payload": response})
         return response
@@ -86,7 +112,6 @@ class MCPPassthrough:
             return json.loads(resp.read())
 
     def _stub_response(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        """Return a minimal valid response when upstream is not configured."""
         method = request.get("method", "")
         req_id = request.get("id")
 
@@ -132,6 +157,7 @@ class MCPPassthrough:
             "rule": decision.rule,
             "tainted": decision.tainted,
             "request_id": request.get("id"),
+            "flow_labels": sorted(self._flow.active_labels()) if self._flow else [],
         })
 
 

--- a/safe_mcp_proxy/atlassian/policy.py
+++ b/safe_mcp_proxy/atlassian/policy.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import yaml
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    decision: str   # "ALLOW" | "DENY" | "ABSENT"
+    rule: str
+    tool: str
+    tainted: bool
+
+
+class ManifestPolicyEngine:
+    """Deterministic policy engine for the Atlassian MCP path.
+
+    Decision order (first match wins):
+    1. ABSENT — tool not in allowlist
+    2. DENY   — tainted source + external-write tool  (flow rule)
+    3. DENY   — argument rule violated
+    4. ALLOW  — default
+    """
+
+    def __init__(self, manifest: Dict[str, Any]) -> None:
+        self._allowlist: Set[str] = set(manifest.get("allowed_tools", []))
+        self._external_write: Set[str] = set(manifest.get("external_write_tools", []))
+        self._arg_rules: Dict[str, List[Dict[str, Any]]] = manifest.get("arg_rules", {})
+        flow = manifest.get("flow_rules", {})
+        self._taint_blocks_external: bool = flow.get(
+            "tainted_source_blocks_external_write", True
+        )
+
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        tainted: bool,
+    ) -> PolicyDecision:
+        # 1. Tool not in allowlist → ABSENT
+        if self._allowlist and tool_name not in self._allowlist:
+            return PolicyDecision("ABSENT", "tool_not_allowlisted", tool_name, tainted)
+
+        # 2. Tainted source + external write → DENY
+        if self._taint_blocks_external and tainted and tool_name in self._external_write:
+            return PolicyDecision(
+                "DENY", "tainted_source_blocks_external_write", tool_name, tainted
+            )
+
+        # 3. Argument-based rules
+        for rule in self._arg_rules.get(tool_name, []):
+            arg_val = arguments.get(rule["arg"])
+            allowed_values = rule.get("allowed_values")
+            if allowed_values is not None and arg_val not in allowed_values:
+                rule_name = rule.get("rule", f"arg_rule:{rule['arg']}")
+                return PolicyDecision("DENY", rule_name, tool_name, tainted)
+
+        # 4. Default allow
+        return PolicyDecision("ALLOW", "default_allow", tool_name, tainted)
+
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "ManifestPolicyEngine":
+        with path.open(encoding="utf-8") as fh:
+            manifest = yaml.safe_load(fh)
+        return cls(manifest or {})

--- a/safe_mcp_proxy/atlassian/policy.py
+++ b/safe_mcp_proxy/atlassian/policy.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import yaml
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
+
+from .flow import DataFlowRule, parse_data_flow_rules
+
+if TYPE_CHECKING:
+    from .flow import FlowContext
 
 
 @dataclass(frozen=True)
@@ -19,9 +24,10 @@ class ManifestPolicyEngine:
 
     Decision order (first match wins):
     1. ABSENT — tool not in allowlist
-    2. DENY   — tainted source + external-write tool  (flow rule)
-    3. DENY   — argument rule violated
-    4. ALLOW  — default
+    2. DENY   — tainted source + external-write tool  (taint flow rule)
+    3. DENY   — data-flow label rule violated          (provenance lite)
+    4. DENY   — argument rule violated
+    5. ALLOW  — default
     """
 
     def __init__(self, manifest: Dict[str, Any]) -> None:
@@ -32,6 +38,9 @@ class ManifestPolicyEngine:
         self._taint_blocks_external: bool = flow.get(
             "tainted_source_blocks_external_write", True
         )
+        self._data_flow_rules: List[DataFlowRule] = parse_data_flow_rules(
+            manifest.get("data_flow_rules", [])
+        )
 
     # ------------------------------------------------------------------
 
@@ -40,6 +49,7 @@ class ManifestPolicyEngine:
         tool_name: str,
         arguments: Dict[str, Any],
         tainted: bool,
+        flow_context: Optional["FlowContext"] = None,
     ) -> PolicyDecision:
         # 1. Tool not in allowlist → ABSENT
         if self._allowlist and tool_name not in self._allowlist:
@@ -51,7 +61,13 @@ class ManifestPolicyEngine:
                 "DENY", "tainted_source_blocks_external_write", tool_name, tainted
             )
 
-        # 3. Argument-based rules
+        # 3. Data-flow label rules (provenance lite)
+        if flow_context is not None:
+            for dfr in self._data_flow_rules:
+                if flow_context.has_label(dfr.if_label) and tool_name in dfr.deny_for:
+                    return PolicyDecision("DENY", dfr.rule, tool_name, tainted)
+
+        # 4. Argument-based rules
         for rule in self._arg_rules.get(tool_name, []):
             arg_val = arguments.get(rule["arg"])
             allowed_values = rule.get("allowed_values")
@@ -59,7 +75,7 @@ class ManifestPolicyEngine:
                 rule_name = rule.get("rule", f"arg_rule:{rule['arg']}")
                 return PolicyDecision("DENY", rule_name, tool_name, tainted)
 
-        # 4. Default allow
+        # 5. Default allow
         return PolicyDecision("ALLOW", "default_allow", tool_name, tainted)
 
     # ------------------------------------------------------------------

--- a/safe_mcp_proxy/atlassian/trace_reader.py
+++ b/safe_mcp_proxy/atlassian/trace_reader.py
@@ -1,0 +1,98 @@
+"""Read and filter Atlassian MCP request/decision traces from JSONL audit log."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class TraceEntry:
+    direction: str          # "request" | "decision" | "response"
+    timestamp: str
+    trace_id: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    tool: Optional[str] = None
+    decision: Optional[str] = None
+    rule: Optional[str] = None
+    tainted: bool = False
+    flow_labels: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "TraceEntry":
+        return cls(
+            direction=d.get("direction", ""),
+            timestamp=d.get("timestamp", ""),
+            trace_id=d.get("trace_id", ""),
+            payload=d.get("payload", {}),
+            tool=d.get("tool"),
+            decision=d.get("decision"),
+            rule=d.get("rule"),
+            tainted=d.get("tainted", False),
+            flow_labels=d.get("flow_labels", []),
+        )
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "direction": self.direction,
+            "timestamp": self.timestamp,
+            "trace_id": self.trace_id,
+            "tool": self.tool,
+            "decision": self.decision,
+            "rule": self.rule,
+            "tainted": self.tainted,
+            "flow_labels": self.flow_labels,
+        }
+
+
+class AtlassianTraceReader:
+    """Read-only interface over an Atlassian requests JSONL log file."""
+
+    def __init__(self, log_path: Path) -> None:
+        self._path = log_path
+
+    # ------------------------------------------------------------------
+
+    def all(self) -> List[TraceEntry]:
+        if not self._path.exists():
+            return []
+        entries = []
+        with self._path.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        entries.append(TraceEntry.from_dict(json.loads(line)))
+                    except (json.JSONDecodeError, KeyError):
+                        continue
+        return entries
+
+    def decisions(self) -> List[TraceEntry]:
+        return [e for e in self.all() if e.direction == "decision"]
+
+    def by_trace(self, trace_id: str) -> List[TraceEntry]:
+        return [e for e in self.all() if e.trace_id == trace_id]
+
+    def filter(
+        self,
+        *,
+        decision: Optional[str] = None,
+        tool: Optional[str] = None,
+        last: Optional[int] = None,
+    ) -> List[TraceEntry]:
+        entries = self.decisions()
+        if decision:
+            entries = [e for e in entries if e.decision == decision.upper()]
+        if tool:
+            entries = [e for e in entries if e.tool == tool]
+        if last:
+            entries = entries[-last:]
+        return entries
+
+    def stats(self) -> Dict[str, Any]:
+        decisions = self.decisions()
+        counts: Dict[str, int] = {}
+        for e in decisions:
+            counts[e.decision or "UNKNOWN"] = counts.get(e.decision or "UNKNOWN", 0) + 1
+        return {"total": len(decisions), "counts": counts}

--- a/safe_mcp_proxy/examples/atlassian_demo.py
+++ b/safe_mcp_proxy/examples/atlassian_demo.py
@@ -1,0 +1,235 @@
+"""
+Atlassian Safe MCP Proxy — Demo Scenario (EPIC 9 / M6)
+=======================================================
+
+Attack prompt: "Summarize the HR policies page and create Jira tasks from it."
+
+A malicious (or simply careless) agent reads a sensitive Confluence page and
+immediately pipes the raw content into a Jira issue.  Without a proxy the data
+leaks into Jira uncontrolled.  With safe-mcp-proxy the write is blocked.
+
+Run:
+    python -m safe_mcp_proxy.examples.atlassian_demo
+
+No real Atlassian credentials are needed — all MCP calls are simulated.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.flow import FlowContext
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine
+
+# ---------------------------------------------------------------------------
+# Mock Atlassian MCP responses
+# ---------------------------------------------------------------------------
+
+_CONFLUENCE_PAGE = {
+    "id": "112233",
+    "title": "HR — Salary Bands & Access Credentials Q2-2026",
+    "body": (
+        "CONFIDENTIAL\n\n"
+        "DB_PASSWORD=s3cr3t!prod\n"
+        "AWS_SECRET_KEY=AKIAIOSFODNN7EXAMPLE/wJalrXUtnFEMI\n\n"
+        "L1 engineer band: $80k–$110k\n"
+        "L2 engineer band: $110k–$145k\n"
+        "L3 engineer band: $145k–$185k\n"
+    ),
+}
+
+_MOCK_UPSTREAM: Dict[str, Any] = {
+    "confluence_get_page": {
+        "jsonrpc": "2.0",
+        "id": None,
+        "result": {
+            "content": [{"type": "text", "text": _CONFLUENCE_PAGE["body"]}],
+            "title": _CONFLUENCE_PAGE["title"],
+        },
+    },
+    "jira_create_issue": {
+        "jsonrpc": "2.0",
+        "id": None,
+        "result": {
+            "content": [{"type": "text", "text": "Issue PROJ-42 created."}],
+            "key": "PROJ-42",
+        },
+    },
+}
+
+
+def _mock_response(tool_name: str, req_id: Any) -> Dict[str, Any]:
+    resp = dict(_MOCK_UPSTREAM.get(tool_name, {"jsonrpc": "2.0", "id": None, "result": {}}))
+    resp["id"] = req_id
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Simulation helpers
+# ---------------------------------------------------------------------------
+
+_SEP = "─" * 64
+
+
+def _header(title: str) -> None:
+    print(f"\n{_SEP}")
+    print(f"  {title}")
+    print(_SEP)
+
+
+def _step(label: str, detail: str = "") -> None:
+    print(f"  → {label}")
+    if detail:
+        for line in detail.splitlines():
+            print(f"      {line}")
+
+
+def _result(label: str, value: str, ok: bool = True) -> None:
+    icon = "✓" if ok else "✗"
+    print(f"  {icon} {label}: {value}")
+
+
+# ---------------------------------------------------------------------------
+# Path A — WITHOUT proxy (direct Atlassian MCP access)
+# ---------------------------------------------------------------------------
+
+def run_without_proxy() -> None:
+    _header("PATH A — WITHOUT safe-mcp-proxy  (attack succeeds)")
+
+    _step("Agent receives prompt", '"Summarize HR policies and create Jira tasks."')
+
+    _step("Agent calls confluence_get_page(page_id=112233)")
+    page_content = _CONFLUENCE_PAGE["body"]
+    _result("Confluence response", f"{len(page_content)} chars of raw content returned", ok=True)
+    _step("Raw content preview", page_content[:120].replace("\n", " ") + "…")
+
+    _step("Agent calls jira_create_issue(summary=<raw content>)")
+    _result("Jira response", "Issue PROJ-42 created  ← CREDENTIALS LEAKED", ok=False)
+
+    print()
+    print("  ⚠  Raw Confluence content (including credentials) now lives in Jira.")
+    print("  ⚠  Visible to everyone with Jira access.")
+
+
+# ---------------------------------------------------------------------------
+# Path B — WITH proxy
+# ---------------------------------------------------------------------------
+
+def run_with_proxy(manifest_path: Path, log_path: Path) -> None:
+    _header("PATH B — WITH safe-mcp-proxy  (attack blocked)")
+
+    _step("Agent receives prompt", '"Summarize HR policies and create Jira tasks."')
+    policy = ManifestPolicyEngine.from_yaml(manifest_path)
+    flow = FlowContext()
+    cfg = AtlassianProxyConfig(upstream_url="", mode="proxy", debug=False)
+    pt = MCPPassthrough(cfg, log_path=log_path, policy=policy, flow_context=flow)
+
+    # --- Step 1: confluence_get_page ---
+    _step("Agent calls confluence_get_page(page_id=112233)")
+
+    import unittest.mock as mock
+
+    read_resp = _mock_response("confluence_get_page", req_id=1)
+    with mock.patch.object(pt, "_stub_response", return_value=read_resp):
+        r1 = pt.forward({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "confluence_get_page", "arguments": {"page_id": "112233"}},
+        })
+
+    if "result" in r1:
+        text = r1["result"]["content"][0]["text"]
+        abstracted = r1["result"].get("_abstraction")
+        _result(
+            "Proxy response",
+            f"{len(text)} chars (truncated to 500)  abstraction={abstracted}",
+            ok=True,
+        )
+        _step("Safe content preview", text[:120].replace("\n", " ") + "…")
+        _step("Flow context after read", str(flow.active_labels()))
+    else:
+        _result("Proxy response", "error — unexpected", ok=False)
+
+    # --- Step 2: jira_create_issue with raw Confluence data ---
+    print()
+    _step(
+        "Agent calls jira_create_issue(summary=<confluence content>)",
+        "  (flow context contains confluence_raw or confluence_summary)",
+    )
+
+    # Simulate the attack: manually inject a raw label to show the block
+    # (In practice, the label is set by tag_output above.)
+    # We reset and inject the raw label to demonstrate the worst case.
+    flow.clear()
+    flow.tag_output("confluence_get_page", was_abstracted=False)  # raw label
+
+    r2 = pt.forward({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {
+            "name": "jira_create_issue",
+            "arguments": {
+                "project_key": "SAFE",
+                "summary": "HR Band data: L1=$80k DB_PASSWORD=s3cr3t!",
+            },
+        },
+    })
+
+    if "error" in r2:
+        decision = r2["error"].get("data", {}).get("decision", "?")
+        rule = r2["error"].get("data", {}).get("rule", "?")
+        _result("Proxy decision", f"BLOCKED  decision={decision}  rule={rule}", ok=False)
+        _result("Jira write", "NOT executed — proxy stopped it before forwarding", ok=True)
+    else:
+        _result("Proxy response", "ALLOWED (unexpected)", ok=False)
+
+
+# ---------------------------------------------------------------------------
+# Audit log summary
+# ---------------------------------------------------------------------------
+
+def print_audit(log_path: Path) -> None:
+    _header("AUDIT LOG  (safe_mcp_proxy/logs/atlassian_requests.jsonl)")
+    entries = [json.loads(l) for l in log_path.read_text().splitlines() if l.strip()]
+    decision_entries = [e for e in entries if e.get("direction") == "decision"]
+    for e in decision_entries:
+        print(
+            f"  [{e['decision']:6}] tool={e['tool']}  "
+            f"rule={e['rule']}  tainted={e['tainted']}  "
+            f"flow={e.get('flow_labels', [])}"
+        )
+    if not decision_entries:
+        print("  (no decision entries yet)")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    manifest_path = Path(__file__).resolve().parents[2] / "manifests" / "atlassian_mvp.yaml"
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+        log_path = Path(f.name)
+
+    print()
+    print("=" * 64)
+    print("  Safe MCP Proxy — Atlassian Attack Demo")
+    print("  Attack: 'Summarize HR page and create Jira tasks'")
+    print("=" * 64)
+
+    run_without_proxy()
+    run_with_proxy(manifest_path, log_path)
+    print_audit(log_path)
+
+    print()
+    print(_SEP)
+    print("  CONCLUSION")
+    print(_SEP)
+    print("  Same prompt — different outcome:")
+    print("  Without proxy → credentials reach Jira (data leak)")
+    print("  With proxy    → write blocked, no_raw_confluence_to_jira")
+    print()

--- a/tests/test_atlassian_adapters.py
+++ b/tests/test_atlassian_adapters.py
@@ -1,0 +1,212 @@
+import unittest
+from pathlib import Path
+
+from safe_mcp_proxy.atlassian.adapters import (
+    ATLASSIAN_TOOLS,
+    COMPOSITE_TOOLS,
+    ToolAdapter,
+    apply_safe_abstraction,
+)
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry(unittest.TestCase):
+    def test_registry_non_empty(self):
+        self.assertGreater(len(ATLASSIAN_TOOLS), 0)
+
+    def test_all_entries_are_tool_adapters(self):
+        for name, adapter in ATLASSIAN_TOOLS.items():
+            self.assertIsInstance(adapter, ToolAdapter)
+            self.assertEqual(adapter.name, name)
+
+    def test_service_values_are_valid(self):
+        valid = {"jira", "confluence"}
+        for adapter in ATLASSIAN_TOOLS.values():
+            self.assertIn(adapter.service, valid, adapter.name)
+
+    def test_side_effect_values_are_valid(self):
+        for adapter in ATLASSIAN_TOOLS.values():
+            self.assertIn(adapter.side_effect, {"read", "write"}, adapter.name)
+
+    def test_jira_read_tools_present(self):
+        for name in ("jira_get_issue", "jira_search_issues_using_jql", "jira_get_transitions"):
+            self.assertIn(name, ATLASSIAN_TOOLS)
+
+    def test_jira_write_tools_present(self):
+        for name in ("jira_create_issue", "jira_update_issue", "jira_transition_issue"):
+            self.assertIn(name, ATLASSIAN_TOOLS)
+
+    def test_confluence_read_tools_present(self):
+        for name in ("confluence_get_page", "confluence_search_pages"):
+            self.assertIn(name, ATLASSIAN_TOOLS)
+
+    def test_composite_tools_list(self):
+        self.assertIn("jira_bulk_create_issues", COMPOSITE_TOOLS)
+        self.assertIn("jira_delete_issue", COMPOSITE_TOOLS)
+
+    def test_composite_tools_are_not_atomic(self):
+        for name in COMPOSITE_TOOLS:
+            self.assertFalse(ATLASSIAN_TOOLS[name].atomic, name)
+
+    def test_confluence_get_page_has_safe_alias(self):
+        adapter = ATLASSIAN_TOOLS["confluence_get_page"]
+        self.assertEqual(adapter.safe_alias, "confluence_get_page_summary")
+
+    def test_read_tools_have_no_safe_alias_by_default(self):
+        # Only confluence_get_page currently has one
+        without_alias = [
+            a for n, a in ATLASSIAN_TOOLS.items()
+            if n != "confluence_get_page"
+        ]
+        for adapter in without_alias:
+            self.assertIsNone(adapter.safe_alias, adapter.name)
+
+
+# ---------------------------------------------------------------------------
+# apply_safe_abstraction
+# ---------------------------------------------------------------------------
+
+
+class TestApplySafeAbstraction(unittest.TestCase):
+    def _response(self, text: str) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": text}]},
+        }
+
+    def test_no_abstraction_for_unknown_tool(self):
+        resp = self._response("hello")
+        result = apply_safe_abstraction("unknown_tool", resp)
+        self.assertEqual(result, resp)
+
+    def test_no_abstraction_for_tool_without_alias(self):
+        resp = self._response("hello")
+        result = apply_safe_abstraction("jira_get_issue", resp)
+        self.assertEqual(result, resp)
+
+    def test_confluence_get_page_truncates_long_text(self):
+        long_text = "x" * 1000
+        resp = self._response(long_text)
+        result = apply_safe_abstraction("confluence_get_page", resp)
+        text = result["result"]["content"][0]["text"]
+        self.assertLessEqual(len(text), 510)  # 500 + "…"
+        self.assertTrue(text.endswith("…"))
+        self.assertTrue(result["result"]["content"][0].get("_truncated"))
+
+    def test_confluence_get_page_short_text_not_truncated(self):
+        resp = self._response("short text")
+        result = apply_safe_abstraction("confluence_get_page", resp)
+        text = result["result"]["content"][0]["text"]
+        self.assertEqual(text, "short text")
+        self.assertNotIn("_truncated", result["result"]["content"][0])
+
+    def test_abstraction_adds_alias_field(self):
+        resp = self._response("content")
+        result = apply_safe_abstraction("confluence_get_page", resp)
+        self.assertEqual(result["result"]["_abstraction"], "confluence_get_page_summary")
+
+    def test_does_not_mutate_original_response(self):
+        long_text = "x" * 1000
+        resp = self._response(long_text)
+        apply_safe_abstraction("confluence_get_page", resp)
+        self.assertEqual(len(resp["result"]["content"][0]["text"]), 1000)
+
+    def test_empty_content_list(self):
+        resp = {"jsonrpc": "2.0", "id": 1, "result": {"content": []}}
+        result = apply_safe_abstraction("confluence_get_page", resp)
+        self.assertEqual(result["result"]["content"], [])
+
+    def test_non_text_blocks_pass_through(self):
+        resp = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "image", "data": "base64..."}]},
+        }
+        result = apply_safe_abstraction("confluence_get_page", resp)
+        self.assertEqual(result["result"]["content"][0]["type"], "image")
+
+
+# ---------------------------------------------------------------------------
+# Integration: safe abstraction applied in MCPPassthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughSafeAbstraction(unittest.TestCase):
+    def test_confluence_get_page_response_truncated(self):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        pt = MCPPassthrough(cfg)
+
+        # Simulate an upstream response by patching _stub_response
+        import unittest.mock as mock
+        long_text = "z" * 1000
+        stub_resp = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": long_text}]},
+        }
+        with mock.patch.object(pt, "_stub_response", return_value=stub_resp):
+            resp = pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "confluence_get_page", "arguments": {"page_id": "123"}},
+            })
+        text = resp["result"]["content"][0]["text"]
+        self.assertLessEqual(len(text), 510)
+        self.assertEqual(resp["result"]["_abstraction"], "confluence_get_page_summary")
+
+    def test_jira_get_issue_response_not_modified(self):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        pt = MCPPassthrough(cfg)
+        stub_resp = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"content": [{"type": "text", "text": "PROJ-1: Fix bug"}]},
+        }
+        import unittest.mock as mock
+        with mock.patch.object(pt, "_stub_response", return_value=stub_resp):
+            resp = pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}},
+            })
+        self.assertNotIn("_abstraction", resp.get("result", {}))
+
+
+# ---------------------------------------------------------------------------
+# Manifest consistency check
+# ---------------------------------------------------------------------------
+
+
+class TestManifestConsistency(unittest.TestCase):
+    def _load_manifest(self):
+        import yaml
+        path = Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
+        with path.open(encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    def test_all_manifest_tools_in_adapter_registry(self):
+        manifest = self._load_manifest()
+        for tool in manifest.get("allowed_tools", []):
+            self.assertIn(tool, ATLASSIAN_TOOLS, f"{tool!r} in manifest but not in adapters")
+
+    def test_no_composite_tools_in_manifest_allowlist(self):
+        manifest = self._load_manifest()
+        composite = set(COMPOSITE_TOOLS)
+        for tool in manifest.get("allowed_tools", []):
+            self.assertNotIn(tool, composite, f"Composite tool {tool!r} in allowlist")
+
+    def test_external_write_tools_match_write_adapters(self):
+        manifest = self._load_manifest()
+        for tool in manifest.get("external_write_tools", []):
+            adapter = ATLASSIAN_TOOLS.get(tool)
+            self.assertIsNotNone(adapter, tool)
+            self.assertEqual(adapter.side_effect, "write", tool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_demo.py
+++ b/tests/test_atlassian_demo.py
@@ -1,0 +1,142 @@
+"""Smoke tests for the Atlassian demo scenario (EPIC 9 / M6).
+
+Verifies that the core attack-and-block sequence runs correctly without
+needing real Atlassian credentials.
+"""
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.flow import FlowContext, LABEL_CONFLUENCE_RAW
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine
+
+_MANIFEST_PATH = Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
+
+_CONFLUENCE_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "content": [{"type": "text", "text": "CONFIDENTIAL\nDB_PASSWORD=s3cr3t!prod\n" * 20}],
+        "title": "HR Policies",
+    },
+}
+
+
+class TestAtlassianDemoScenario(unittest.TestCase):
+    """End-to-end smoke test of the attack scenario used in the demo."""
+
+    def _make_proxy(self, log_path=None):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        policy = ManifestPolicyEngine.from_yaml(_MANIFEST_PATH)
+        flow = FlowContext()
+        return MCPPassthrough(cfg, log_path=log_path, policy=policy, flow_context=flow), flow
+
+    # ------------------------------------------------------------------
+
+    def test_confluence_read_succeeds_and_is_abstracted(self):
+        pt, flow = self._make_proxy()
+        with patch.object(pt, "_stub_response", return_value=_CONFLUENCE_RESPONSE):
+            resp = pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "confluence_get_page", "arguments": {"page_id": "1"}},
+            })
+        self.assertNotIn("error", resp)
+        text = resp["result"]["content"][0]["text"]
+        self.assertLessEqual(len(text), 510, "Content should be truncated by safe abstraction")
+        self.assertEqual(resp["result"].get("_abstraction"), "confluence_get_page_summary")
+
+    def test_jira_write_blocked_after_raw_confluence_read(self):
+        pt, flow = self._make_proxy()
+        # Inject raw label (simulating read without abstraction)
+        flow.tag_output("confluence_get_page", was_abstracted=False)
+
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {
+                "name": "jira_create_issue",
+                "arguments": {"project_key": "SAFE", "summary": "leaked data"},
+            },
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["decision"], "DENY")
+        self.assertEqual(resp["error"]["data"]["rule"], "no_raw_confluence_to_jira")
+
+    def test_jira_write_allowed_when_no_confluence_read(self):
+        pt, _ = self._make_proxy()
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {
+                "name": "jira_create_issue",
+                "arguments": {"project_key": "SAFE", "summary": "normal task"},
+            },
+        })
+        # No flow label → policy allows (stub returns isError because no upstream)
+        self.assertNotIn("error", resp)
+
+    def test_composite_tool_is_absent(self):
+        pt, _ = self._make_proxy()
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "jira_bulk_create_issues", "arguments": {}},
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["decision"], "ABSENT")
+
+    def test_audit_log_records_allow_then_deny(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            pt, flow = self._make_proxy(log_path=log_path)
+
+            # Step 1: read
+            with patch.object(pt, "_stub_response", return_value=_CONFLUENCE_RESPONSE):
+                pt.forward({
+                    "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                    "params": {"name": "confluence_get_page", "arguments": {"page_id": "1"}},
+                })
+
+            # Inject raw label then write
+            flow.clear()
+            flow.tag_output("confluence_get_page", was_abstracted=False)
+            pt.forward({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {
+                    "name": "jira_create_issue",
+                    "arguments": {"project_key": "SAFE", "summary": "leaked"},
+                },
+            })
+
+            entries = [json.loads(l) for l in log_path.read_text().splitlines()]
+            decisions = [e for e in entries if e.get("direction") == "decision"]
+
+        self.assertEqual(len(decisions), 2)
+        self.assertEqual(decisions[0]["decision"], "ALLOW")
+        self.assertEqual(decisions[0]["tool"], "confluence_get_page")
+        self.assertEqual(decisions[1]["decision"], "DENY")
+        self.assertEqual(decisions[1]["rule"], "no_raw_confluence_to_jira")
+
+    def test_demo_script_runs_without_error(self):
+        """Full demo script produces output and exits cleanly."""
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            from safe_mcp_proxy.examples import atlassian_demo
+            import importlib
+            # Re-run the module's main block via the functions directly
+            with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+                log_path = Path(f.name)
+            atlassian_demo.run_without_proxy()
+            atlassian_demo.run_with_proxy(_MANIFEST_PATH, log_path)
+
+        output = captured.getvalue()
+        self.assertIn("BLOCKED", output)
+        self.assertIn("no_raw_confluence_to_jira", output)
+        self.assertIn("CREDENTIALS LEAKED", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_filter.py
+++ b/tests/test_atlassian_filter.py
@@ -1,0 +1,176 @@
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.filter import CapabilityFilter
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+
+_TOOLS = [
+    {"name": "jira_read_issue", "description": "Read a Jira issue"},
+    {"name": "jira_create_issue", "description": "Create a Jira issue"},
+    {"name": "jira_bulk_create_all_issues", "description": "Bulk-create every issue"},
+    {"name": "confluence_read_page", "description": "Read a Confluence page"},
+]
+
+
+# ---------------------------------------------------------------------------
+# CapabilityFilter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityFilter(unittest.TestCase):
+    def test_passthrough_when_allowlist_empty(self):
+        f = CapabilityFilter(allowed_tools=set(), denied_tools=set())
+        result = f.filter_tools(_TOOLS)
+        self.assertEqual(len(result), len(_TOOLS))
+
+    def test_allowlist_hides_unlisted_tools(self):
+        f = CapabilityFilter(allowed_tools={"jira_read_issue"}, denied_tools=set())
+        result = f.filter_tools(_TOOLS)
+        self.assertEqual([t["name"] for t in result], ["jira_read_issue"])
+
+    def test_denylist_removes_tool_even_if_in_allowlist(self):
+        f = CapabilityFilter(
+            allowed_tools={"jira_read_issue", "jira_bulk_create_all_issues"},
+            denied_tools={"jira_bulk_create_all_issues"},
+        )
+        result = f.filter_tools(_TOOLS)
+        self.assertEqual([t["name"] for t in result], ["jira_read_issue"])
+
+    def test_denylist_without_allowlist(self):
+        f = CapabilityFilter(
+            allowed_tools=set(),
+            denied_tools={"jira_bulk_create_all_issues"},
+        )
+        result = f.filter_tools(_TOOLS)
+        names = [t["name"] for t in result]
+        self.assertNotIn("jira_bulk_create_all_issues", names)
+        self.assertIn("jira_read_issue", names)
+        self.assertEqual(len(result), len(_TOOLS) - 1)
+
+    def test_empty_tools_list(self):
+        f = CapabilityFilter(allowed_tools={"jira_read_issue"}, denied_tools=set())
+        self.assertEqual(f.filter_tools([]), [])
+
+    def test_tool_without_name_key_is_excluded_by_allowlist(self):
+        f = CapabilityFilter(allowed_tools={"jira_read_issue"}, denied_tools=set())
+        result = f.filter_tools([{"description": "no name"}])
+        self.assertEqual(result, [])
+
+    def test_apply_to_list_response_wraps_result(self):
+        f = CapabilityFilter(allowed_tools={"jira_read_issue"}, denied_tools=set())
+        response = {"jsonrpc": "2.0", "id": 1, "result": {"tools": _TOOLS}}
+        filtered = f.apply_to_list_response(response)
+        self.assertEqual(filtered["jsonrpc"], "2.0")
+        self.assertEqual(filtered["id"], 1)
+        self.assertEqual(len(filtered["result"]["tools"]), 1)
+        self.assertEqual(filtered["result"]["tools"][0]["name"], "jira_read_issue")
+
+    def test_apply_to_list_response_does_not_mutate_input(self):
+        f = CapabilityFilter(allowed_tools={"jira_read_issue"}, denied_tools=set())
+        response = {"jsonrpc": "2.0", "id": 1, "result": {"tools": _TOOLS}}
+        f.apply_to_list_response(response)
+        self.assertEqual(len(response["result"]["tools"]), len(_TOOLS))
+
+
+# ---------------------------------------------------------------------------
+# Config env-var parsing for allowed/denied tools
+# ---------------------------------------------------------------------------
+
+
+class TestConfigToolsParsing(unittest.TestCase):
+    def test_allowed_tools_from_env(self):
+        with patch.dict(os.environ, {"ATLASSIAN_ALLOWED_TOOLS": "jira_read_issue, confluence_read_page"}):
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.allowed_tools, {"jira_read_issue", "confluence_read_page"})
+
+    def test_denied_tools_from_env(self):
+        with patch.dict(os.environ, {"ATLASSIAN_DENIED_TOOLS": "jira_bulk_create_all_issues"}):
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.denied_tools, {"jira_bulk_create_all_issues"})
+
+    def test_empty_env_gives_empty_sets(self):
+        for k in ("ATLASSIAN_ALLOWED_TOOLS", "ATLASSIAN_DENIED_TOOLS"):
+            os.environ.pop(k, None)
+        cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.allowed_tools, set())
+        self.assertEqual(cfg.denied_tools, set())
+
+    def test_capability_filter_factory(self):
+        cfg = AtlassianProxyConfig(
+            allowed_tools={"jira_read_issue"},
+            denied_tools={"jira_bulk_create_all_issues"},
+        )
+        f = cfg.capability_filter()
+        self.assertIsInstance(f, CapabilityFilter)
+
+
+# ---------------------------------------------------------------------------
+# Integration: filter applied inside MCPPassthrough.forward()
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughFiltering(unittest.TestCase):
+    def _stub_passthrough(self, allowed=None, denied=None):
+        cfg = AtlassianProxyConfig(
+            upstream_url="",
+            mode="proxy",
+            allowed_tools=set(allowed or []),
+            denied_tools=set(denied or []),
+        )
+        return MCPPassthrough(cfg)
+
+    def _upstream_passthrough(self, allowed=None, denied=None):
+        cfg = AtlassianProxyConfig(
+            upstream_url="http://upstream",
+            mode="proxy",
+            allowed_tools=set(allowed or []),
+            denied_tools=set(denied or []),
+        )
+        return MCPPassthrough(cfg)
+
+    def _mock_upstream(self, tools):
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=cm)
+        cm.__exit__ = MagicMock(return_value=False)
+        cm.read.return_value = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "result": {"tools": tools}}
+        ).encode()
+        return cm
+
+    def test_stub_list_tools_no_filter_returns_empty(self):
+        pt = self._stub_passthrough()
+        resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        self.assertEqual(resp["result"]["tools"], [])
+
+    def test_upstream_list_tools_filtered_by_allowlist(self):
+        pt = self._upstream_passthrough(allowed=["jira_read_issue"])
+        with patch("urllib.request.urlopen", return_value=self._mock_upstream(_TOOLS)):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        self.assertEqual([t["name"] for t in resp["result"]["tools"]], ["jira_read_issue"])
+
+    def test_upstream_list_tools_deny_composite(self):
+        pt = self._upstream_passthrough(denied=["jira_bulk_create_all_issues"])
+        with patch("urllib.request.urlopen", return_value=self._mock_upstream(_TOOLS)):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        names = [t["name"] for t in resp["result"]["tools"]]
+        self.assertNotIn("jira_bulk_create_all_issues", names)
+        self.assertIn("jira_read_issue", names)
+
+    def test_filter_not_applied_to_other_methods(self):
+        pt = self._upstream_passthrough(allowed=["jira_read_issue"])
+        upstream_resp = {"jsonrpc": "2.0", "id": 2, "result": {"content": []}}
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=cm)
+        cm.__exit__ = MagicMock(return_value=False)
+        cm.read.return_value = json.dumps(upstream_resp).encode()
+        with patch("urllib.request.urlopen", return_value=cm):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                               "params": {"name": "jira_read_issue", "arguments": {}}})
+        self.assertEqual(resp, upstream_resp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_flow.py
+++ b/tests/test_atlassian_flow.py
@@ -1,0 +1,233 @@
+import unittest
+from pathlib import Path
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.flow import (
+    LABEL_CONFLUENCE_RAW,
+    LABEL_CONFLUENCE_SUMMARY,
+    FlowContext,
+    parse_data_flow_rules,
+)
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine
+
+_MANIFEST = {
+    "allowed_tools": [
+        "jira_get_issue", "jira_create_issue", "jira_add_comment", "confluence_get_page"
+    ],
+    "external_write_tools": ["jira_create_issue", "jira_add_comment"],
+    "arg_rules": {},
+    "flow_rules": {"tainted_source_blocks_external_write": True},
+    "data_flow_rules": [
+        {
+            "if_label": LABEL_CONFLUENCE_RAW,
+            "deny_for": ["jira_create_issue", "jira_add_comment"],
+            "rule": "no_raw_confluence_to_jira",
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# FlowContext unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlowContext(unittest.TestCase):
+    def test_initially_empty(self):
+        fc = FlowContext()
+        self.assertEqual(fc.active_labels(), set())
+
+    def test_tag_output_confluence_get_page_raw(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        self.assertTrue(fc.has_label(LABEL_CONFLUENCE_RAW))
+        self.assertFalse(fc.has_label(LABEL_CONFLUENCE_SUMMARY))
+
+    def test_tag_output_confluence_get_page_abstracted(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=True)
+        self.assertTrue(fc.has_label(LABEL_CONFLUENCE_SUMMARY))
+        self.assertFalse(fc.has_label(LABEL_CONFLUENCE_RAW))
+
+    def test_tag_output_unknown_tool_adds_nothing(self):
+        fc = FlowContext()
+        fc.tag_output("jira_get_issue", was_abstracted=False)
+        self.assertEqual(fc.active_labels(), set())
+
+    def test_clear_removes_all_labels(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        fc.clear()
+        self.assertEqual(fc.active_labels(), set())
+
+    def test_as_dict(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        d = fc.as_dict()
+        self.assertIn("active_labels", d)
+        self.assertIn(LABEL_CONFLUENCE_RAW, d["active_labels"])
+
+    def test_labels_accumulate(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        fc.tag_output("confluence_get_page", was_abstracted=True)
+        self.assertIn(LABEL_CONFLUENCE_RAW, fc.active_labels())
+        self.assertIn(LABEL_CONFLUENCE_SUMMARY, fc.active_labels())
+
+
+# ---------------------------------------------------------------------------
+# parse_data_flow_rules
+# ---------------------------------------------------------------------------
+
+
+class TestParseDataFlowRules(unittest.TestCase):
+    def test_parses_correctly(self):
+        raw = [
+            {
+                "if_label": "confluence_raw",
+                "deny_for": ["jira_create_issue"],
+                "rule": "no_raw_to_jira",
+            }
+        ]
+        rules = parse_data_flow_rules(raw)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].if_label, "confluence_raw")
+        self.assertEqual(rules[0].deny_for, ["jira_create_issue"])
+        self.assertEqual(rules[0].rule, "no_raw_to_jira")
+
+    def test_default_rule_name(self):
+        raw = [{"if_label": "confluence_raw", "deny_for": ["jira_create_issue"]}]
+        rules = parse_data_flow_rules(raw)
+        self.assertIn("confluence_raw", rules[0].rule)
+
+    def test_empty_list(self):
+        self.assertEqual(parse_data_flow_rules([]), [])
+
+
+# ---------------------------------------------------------------------------
+# ManifestPolicyEngine — data_flow_rules
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyEngineDataFlow(unittest.TestCase):
+    def _engine(self):
+        return ManifestPolicyEngine(_MANIFEST)
+
+    def test_deny_when_confluence_raw_flows_to_jira_write(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        d = self._engine().evaluate("jira_create_issue", {}, tainted=False, flow_context=fc)
+        self.assertEqual(d.decision, "DENY")
+        self.assertEqual(d.rule, "no_raw_confluence_to_jira")
+
+    def test_allow_when_confluence_summary_flows_to_jira_write(self):
+        # Summary label is not in deny_for → allowed
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=True)
+        d = self._engine().evaluate("jira_create_issue", {}, tainted=False, flow_context=fc)
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_allow_jira_read_regardless_of_label(self):
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        d = self._engine().evaluate("jira_get_issue", {}, tainted=False, flow_context=fc)
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_no_flow_context_skips_data_flow_rules(self):
+        d = self._engine().evaluate("jira_create_issue", {}, tainted=False, flow_context=None)
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_empty_flow_context_allows(self):
+        fc = FlowContext()  # no labels
+        d = self._engine().evaluate("jira_create_issue", {}, tainted=False, flow_context=fc)
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_taint_rule_evaluated_before_data_flow_rule(self):
+        # Tainted source → DENY via taint rule (rule 2), not data-flow rule (rule 3)
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        d = self._engine().evaluate(
+            "jira_create_issue", {}, tainted=True, flow_context=fc
+        )
+        self.assertEqual(d.decision, "DENY")
+        self.assertEqual(d.rule, "tainted_source_blocks_external_write")
+
+
+# ---------------------------------------------------------------------------
+# Integration: FlowContext wired into MCPPassthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughFlowTracking(unittest.TestCase):
+    def _make(self, debug=False):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy", debug=debug)
+        policy = ManifestPolicyEngine(_MANIFEST)
+        flow = FlowContext()
+        return MCPPassthrough(cfg, policy=policy, flow_context=flow), flow
+
+    def test_confluence_get_page_tags_flow_context(self):
+        pt, flow = self._make()
+        pt.forward({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "confluence_get_page", "arguments": {"page_id": "123"}},
+        })
+        self.assertTrue(
+            flow.has_label(LABEL_CONFLUENCE_SUMMARY),
+            "Expected confluence_summary label (safe abstraction applied)",
+        )
+
+    def test_subsequent_jira_create_denied_after_raw_read(self):
+        # Manually set raw label (not summary) to simulate no-safe-abstraction scenario
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        policy = ManifestPolicyEngine(_MANIFEST)
+        flow = FlowContext()
+        flow.tag_output("confluence_get_page", was_abstracted=False)  # raw label
+        pt = MCPPassthrough(cfg, policy=policy, flow_context=flow)
+
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {}},
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["rule"], "no_raw_confluence_to_jira")
+
+    def test_jira_create_allowed_when_no_flow_context(self):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        policy = ManifestPolicyEngine(_MANIFEST)
+        pt = MCPPassthrough(cfg, policy=policy, flow_context=None)
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {}},
+        })
+        self.assertNotIn("error", resp)
+
+    def test_debug_mode_attaches_flow_context(self):
+        pt, flow = self._make(debug=True)
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "confluence_get_page", "arguments": {"page_id": "1"}},
+        })
+        self.assertIn("_debug", resp.get("result", {}))
+        self.assertIn("flow_context", resp["result"]["_debug"])
+
+    def test_debug_mode_false_no_debug_field(self):
+        pt, _ = self._make(debug=False)
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": {"name": "confluence_get_page", "arguments": {"page_id": "1"}},
+        })
+        self.assertNotIn("_debug", resp.get("result", {}))
+
+    def test_real_manifest_data_flow_rules_loaded(self):
+        manifest_path = Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
+        engine = ManifestPolicyEngine.from_yaml(manifest_path)
+        fc = FlowContext()
+        fc.tag_output("confluence_get_page", was_abstracted=False)
+        d = engine.evaluate("jira_create_issue", {}, tainted=False, flow_context=fc)
+        self.assertEqual(d.decision, "DENY")
+        self.assertEqual(d.rule, "no_raw_confluence_to_jira")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_observability.py
+++ b/tests/test_atlassian_observability.py
@@ -1,0 +1,273 @@
+"""Tests for Atlassian MCP observability: trace_id, TraceReader, CLI."""
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from safe_mcp_proxy.atlassian.cli import main as cli_main
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.flow import FlowContext
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine
+from safe_mcp_proxy.atlassian.trace_reader import AtlassianTraceReader, TraceEntry
+
+_MANIFEST = {
+    "allowed_tools": ["jira_get_issue", "jira_create_issue", "confluence_get_page"],
+    "external_write_tools": ["jira_create_issue"],
+    "arg_rules": {},
+    "flow_rules": {"tainted_source_blocks_external_write": True},
+    "data_flow_rules": [],
+}
+
+
+def _make_proxy(log_path=None):
+    cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+    policy = ManifestPolicyEngine(_MANIFEST)
+    return MCPPassthrough(cfg, log_path=log_path, policy=policy)
+
+
+# ---------------------------------------------------------------------------
+# trace_id in log entries
+# ---------------------------------------------------------------------------
+
+
+class TestTraceId(unittest.TestCase):
+    def test_all_entries_for_one_call_share_trace_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            pt = _make_proxy(log_path)
+            pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_get_issue", "arguments": {"issue_key": "PROJ-1"}},
+            })
+            lines = [json.loads(l) for l in log_path.read_text().splitlines()]
+
+        trace_ids = {l["trace_id"] for l in lines}
+        self.assertEqual(len(trace_ids), 1, "All entries in one forward() must share trace_id")
+
+    def test_different_calls_have_different_trace_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            pt = _make_proxy(log_path)
+            pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_get_issue", "arguments": {}},
+            })
+            pt.forward({
+                "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+                "params": {"name": "jira_get_issue", "arguments": {}},
+            })
+            lines = [json.loads(l) for l in log_path.read_text().splitlines()]
+
+        # Each call produces request + decision + response = 3 entries
+        trace_ids = {l["trace_id"] for l in lines}
+        self.assertEqual(len(trace_ids), 2)
+
+    def test_blocked_call_has_trace_id_in_all_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            pt = _make_proxy(log_path)
+            pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_bulk_delete", "arguments": {}},
+            })
+            lines = [json.loads(l) for l in log_path.read_text().splitlines()]
+
+        self.assertTrue(all("trace_id" in l for l in lines))
+        trace_ids = {l["trace_id"] for l in lines}
+        self.assertEqual(len(trace_ids), 1)
+
+    def test_trace_id_is_uuid_format(self):
+        import re
+        uuid_pattern = re.compile(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            _make_proxy(log_path).forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_get_issue", "arguments": {}},
+            })
+            line = json.loads(log_path.read_text().splitlines()[0])
+        self.assertRegex(line["trace_id"], uuid_pattern)
+
+
+# ---------------------------------------------------------------------------
+# AtlassianTraceReader
+# ---------------------------------------------------------------------------
+
+
+class TestAtlassianTraceReader(unittest.TestCase):
+    def _write_log(self, tmp, entries):
+        log_path = Path(tmp) / "log.jsonl"
+        with log_path.open("w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        return log_path
+
+    def _sample_entries(self):
+        return [
+            {"direction": "request", "timestamp": "2026-01-01T00:00:00Z",
+             "trace_id": "aaa", "payload": {}},
+            {"direction": "decision", "timestamp": "2026-01-01T00:00:01Z",
+             "trace_id": "aaa", "tool": "jira_get_issue", "decision": "ALLOW",
+             "rule": "default_allow", "tainted": False, "flow_labels": []},
+            {"direction": "response", "timestamp": "2026-01-01T00:00:02Z",
+             "trace_id": "aaa", "payload": {}},
+            {"direction": "request", "timestamp": "2026-01-01T00:01:00Z",
+             "trace_id": "bbb", "payload": {}},
+            {"direction": "decision", "timestamp": "2026-01-01T00:01:01Z",
+             "trace_id": "bbb", "tool": "jira_create_issue", "decision": "DENY",
+             "rule": "tainted_source_blocks_external_write", "tainted": True,
+             "flow_labels": []},
+            {"direction": "response", "timestamp": "2026-01-01T00:01:02Z",
+             "trace_id": "bbb", "payload": {}},
+        ]
+
+    def test_all_returns_all_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            entries = AtlassianTraceReader(log_path).all()
+        self.assertEqual(len(entries), 6)
+
+    def test_decisions_returns_only_decisions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            decisions = AtlassianTraceReader(log_path).decisions()
+        self.assertEqual(len(decisions), 2)
+        self.assertTrue(all(e.direction == "decision" for e in decisions))
+
+    def test_filter_by_decision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            denied = AtlassianTraceReader(log_path).filter(decision="DENY")
+        self.assertEqual(len(denied), 1)
+        self.assertEqual(denied[0].tool, "jira_create_issue")
+
+    def test_filter_by_tool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            result = AtlassianTraceReader(log_path).filter(tool="jira_get_issue")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].decision, "ALLOW")
+
+    def test_filter_last(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            result = AtlassianTraceReader(log_path).filter(last=1)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].trace_id, "bbb")
+
+    def test_by_trace_returns_all_entries_for_trace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            result = AtlassianTraceReader(log_path).by_trace("aaa")
+        self.assertEqual(len(result), 3)
+        self.assertTrue(all(e.trace_id == "aaa" for e in result))
+
+    def test_stats(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp, self._sample_entries())
+            stats = AtlassianTraceReader(log_path).stats()
+        self.assertEqual(stats["total"], 2)
+        self.assertEqual(stats["counts"]["ALLOW"], 1)
+        self.assertEqual(stats["counts"]["DENY"], 1)
+
+    def test_missing_log_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = AtlassianTraceReader(Path(tmp) / "missing.jsonl").all()
+        self.assertEqual(result, [])
+
+    def test_malformed_line_is_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            log_path.write_text('not json\n{"direction":"decision","timestamp":"t",'
+                                '"trace_id":"x","tool":"t","decision":"ALLOW"}\n')
+            entries = AtlassianTraceReader(log_path).all()
+        self.assertEqual(len(entries), 1)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestAtlassianCLI(unittest.TestCase):
+    def _write_log(self, tmp):
+        log_path = Path(tmp) / "log.jsonl"
+        entries = [
+            {"direction": "decision", "timestamp": "2026-01-01T00:00:01Z",
+             "trace_id": "aaaa-1234", "tool": "jira_get_issue", "decision": "ALLOW",
+             "rule": "default_allow", "tainted": False, "flow_labels": []},
+            {"direction": "decision", "timestamp": "2026-01-01T00:01:01Z",
+             "trace_id": "bbbb-5678", "tool": "jira_create_issue", "decision": "DENY",
+             "rule": "no_raw_confluence_to_jira", "tainted": False,
+             "flow_labels": ["confluence_raw"]},
+        ]
+        with log_path.open("w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        return log_path
+
+    def test_list_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp)
+            with patch("sys.stdout", io.StringIO()) as out:
+                rc = cli_main(["list", "--log", str(log_path)])
+        self.assertEqual(rc, 0)
+        output = out.getvalue()
+        self.assertIn("jira_get_issue", output)
+        self.assertIn("ALLOW", output)
+        self.assertIn("DENY", output)
+
+    def test_stats_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp)
+            with patch("sys.stdout", io.StringIO()) as out:
+                rc = cli_main(["stats", "--log", str(log_path)])
+        self.assertEqual(rc, 0)
+        output = out.getvalue()
+        self.assertIn("2", output)  # total
+
+    def test_filter_by_decision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp)
+            with patch("sys.stdout", io.StringIO()) as out:
+                cli_main(["list", "--log", str(log_path), "--decision", "DENY"])
+        output = out.getvalue()
+        self.assertIn("jira_create_issue", output)
+        self.assertNotIn("jira_get_issue", output)
+
+    def test_trace_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp)
+            # Add request + response entries for trace aaaa-1234
+            with log_path.open("a") as f:
+                f.write(json.dumps({"direction": "request", "timestamp": "t",
+                                    "trace_id": "aaaa-1234", "payload": {}}) + "\n")
+            with patch("sys.stdout", io.StringIO()) as out:
+                rc = cli_main(["trace", "--log", str(log_path), "--trace-id", "aaaa-1234"])
+        self.assertEqual(rc, 0)
+        output = out.getvalue()
+        self.assertIn("aaaa-1234", output)
+
+    def test_trace_command_missing_trace_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = self._write_log(tmp)
+            rc = cli_main(["trace", "--log", str(log_path)])
+        self.assertEqual(rc, 1)
+
+    def test_empty_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "empty.jsonl"
+            log_path.write_text("")
+            with patch("sys.stdout", io.StringIO()) as out:
+                rc = cli_main(["list", "--log", str(log_path)])
+        self.assertEqual(rc, 0)
+        self.assertIn("No entries", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_passthrough.py
+++ b/tests/test_atlassian_passthrough.py
@@ -1,0 +1,187 @@
+import json
+import os
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestAtlassianProxyConfig(unittest.TestCase):
+    def test_defaults(self):
+        cfg = AtlassianProxyConfig()
+        self.assertEqual(cfg.upstream_url, "")
+        self.assertEqual(cfg.mode, "proxy")
+        self.assertEqual(cfg.timeout, 30)
+        self.assertTrue(cfg.is_proxy_mode)
+
+    def test_from_env(self):
+        env = {
+            "ATLASSIAN_MCP_URL": "http://localhost:9000",
+            "ATLASSIAN_PROXY_MODE": "direct",
+            "ATLASSIAN_MCP_TIMEOUT": "15",
+        }
+        with patch.dict(os.environ, env):
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.upstream_url, "http://localhost:9000")
+        self.assertEqual(cfg.mode, "direct")
+        self.assertEqual(cfg.timeout, 15)
+        self.assertFalse(cfg.is_proxy_mode)
+
+    def test_from_env_defaults_when_vars_absent(self):
+        clean = {k: "" for k in ("ATLASSIAN_MCP_URL", "ATLASSIAN_PROXY_MODE", "ATLASSIAN_MCP_TIMEOUT")}
+        with patch.dict(os.environ, {}, clear=False):
+            for k in ("ATLASSIAN_MCP_URL", "ATLASSIAN_PROXY_MODE", "ATLASSIAN_MCP_TIMEOUT"):
+                os.environ.pop(k, None)
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.upstream_url, "")
+        self.assertEqual(cfg.mode, "proxy")
+        self.assertEqual(cfg.timeout, 30)
+
+
+# ---------------------------------------------------------------------------
+# Passthrough stub responses (no upstream configured)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPPassthroughStub(unittest.TestCase):
+    def _make(self, log_path=None):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        return MCPPassthrough(cfg, log_path)
+
+    def test_list_tools_returns_empty_tools(self):
+        pt = self._make()
+        resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+        self.assertEqual(resp["jsonrpc"], "2.0")
+        self.assertEqual(resp["id"], 1)
+        self.assertIn("tools", resp["result"])
+        self.assertIsInstance(resp["result"]["tools"], list)
+
+    def test_call_tool_returns_is_error(self):
+        pt = self._make()
+        resp = pt.forward({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {}},
+        })
+        self.assertEqual(resp["id"], 2)
+        self.assertTrue(resp["result"]["isError"])
+
+    def test_initialize_returns_server_info(self):
+        pt = self._make()
+        resp = pt.forward({"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {}})
+        self.assertEqual(resp["id"], 0)
+        self.assertIn("serverInfo", resp["result"])
+        self.assertEqual(resp["result"]["serverInfo"]["name"], "safe-mcp-proxy/atlassian")
+
+    def test_unknown_method_returns_empty_result(self):
+        pt = self._make()
+        resp = pt.forward({"jsonrpc": "2.0", "id": 99, "method": "notifications/initialized"})
+        self.assertEqual(resp["id"], 99)
+        self.assertEqual(resp["result"], {})
+
+    def test_direct_mode_also_stubs(self):
+        cfg = AtlassianProxyConfig(upstream_url="http://real-upstream", mode="direct")
+        pt = MCPPassthrough(cfg)
+        resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+        self.assertEqual(resp["result"]["tools"], [])
+
+
+# ---------------------------------------------------------------------------
+# Passthrough HTTP forwarding (mocked upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPPassthroughHTTP(unittest.TestCase):
+    def _make(self, url="http://upstream:9000"):
+        cfg = AtlassianProxyConfig(upstream_url=url, mode="proxy")
+        return MCPPassthrough(cfg)
+
+    def _mock_urlopen(self, body: dict):
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=cm)
+        cm.__exit__ = MagicMock(return_value=False)
+        cm.read.return_value = json.dumps(body).encode()
+        return cm
+
+    def test_forwards_request_and_returns_response(self):
+        upstream_resp = {"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "jira_read"}]}}
+        pt = self._make()
+        with patch("urllib.request.urlopen", return_value=self._mock_urlopen(upstream_resp)):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+        self.assertEqual(resp["result"]["tools"][0]["name"], "jira_read")
+
+    def test_url_error_returns_json_rpc_error(self):
+        pt = self._make()
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("refused")):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 5, "method": "tools/list", "params": {}})
+        self.assertIn("error", resp)
+        self.assertEqual(resp["id"], 5)
+        self.assertEqual(resp["error"]["code"], -32603)
+
+    def test_os_error_returns_json_rpc_error(self):
+        pt = self._make()
+        with patch("urllib.request.urlopen", side_effect=OSError("connection reset")):
+            resp = pt.forward({"jsonrpc": "2.0", "id": 6, "method": "tools/call"})
+        self.assertIn("error", resp)
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+class TestMCPPassthroughLogging(unittest.TestCase):
+    def test_logs_request_and_response(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "logs" / "atlassian_requests.jsonl"
+            cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+            pt = MCPPassthrough(cfg, log_path)
+            pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+
+            lines = log_path.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 2)
+            req_entry = json.loads(lines[0])
+            resp_entry = json.loads(lines[1])
+            self.assertEqual(req_entry["direction"], "request")
+            self.assertEqual(resp_entry["direction"], "response")
+            self.assertIn("timestamp", req_entry)
+            self.assertIn("timestamp", resp_entry)
+
+    def test_creates_log_dir_if_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "deep" / "nested" / "log.jsonl"
+            cfg = AtlassianProxyConfig()
+            MCPPassthrough(cfg, log_path).forward(
+                {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+            )
+            self.assertTrue(log_path.exists())
+
+    def test_no_log_path_is_silent(self):
+        cfg = AtlassianProxyConfig()
+        pt = MCPPassthrough(cfg, log_path=None)
+        # Must not raise
+        pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    def test_log_appends(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            cfg = AtlassianProxyConfig()
+            pt = MCPPassthrough(cfg, log_path)
+            pt.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+            pt.forward({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            lines = log_path.read_text().strip().splitlines()
+            self.assertEqual(len(lines), 4)  # 2 pairs of request+response
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_policy.py
+++ b/tests/test_atlassian_policy.py
@@ -1,0 +1,232 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from safe_mcp_proxy.atlassian.config import AtlassianProxyConfig
+from safe_mcp_proxy.atlassian.passthrough import MCPPassthrough
+from safe_mcp_proxy.atlassian.policy import ManifestPolicyEngine, PolicyDecision
+
+# Minimal manifest used across tests
+_MANIFEST = {
+    "world_id": "test_world",
+    "allowed_tools": ["jira_read_issue", "jira_create_issue"],
+    "external_write_tools": ["jira_create_issue"],
+    "arg_rules": {
+        "jira_create_issue": [
+            {
+                "arg": "project_key",
+                "allowed_values": ["SAFE", "TEST"],
+                "rule": "jira_create_restricted_projects",
+            }
+        ]
+    },
+    "flow_rules": {"tainted_source_blocks_external_write": True},
+}
+
+
+# ---------------------------------------------------------------------------
+# ManifestPolicyEngine unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestManifestPolicyEngine(unittest.TestCase):
+    def _engine(self, manifest=None):
+        return ManifestPolicyEngine(manifest or _MANIFEST)
+
+    # --- ABSENT decisions ---
+
+    def test_absent_when_tool_not_in_allowlist(self):
+        d = self._engine().evaluate("jira_bulk_delete", {}, tainted=False)
+        self.assertEqual(d.decision, "ABSENT")
+        self.assertEqual(d.rule, "tool_not_allowlisted")
+        self.assertEqual(d.tool, "jira_bulk_delete")
+
+    def test_passthrough_mode_when_allowlist_empty(self):
+        engine = ManifestPolicyEngine({})
+        d = engine.evaluate("anything", {}, tainted=False)
+        self.assertEqual(d.decision, "ALLOW")
+
+    # --- DENY: flow rule ---
+
+    def test_deny_tainted_source_external_write(self):
+        d = self._engine().evaluate("jira_create_issue", {"project_key": "SAFE"}, tainted=True)
+        self.assertEqual(d.decision, "DENY")
+        self.assertEqual(d.rule, "tainted_source_blocks_external_write")
+
+    def test_allow_read_tool_even_if_tainted(self):
+        d = self._engine().evaluate("jira_read_issue", {}, tainted=True)
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_flow_rule_disabled_allows_tainted_external_write(self):
+        manifest = {**_MANIFEST, "flow_rules": {"tainted_source_blocks_external_write": False}}
+        d = ManifestPolicyEngine(manifest).evaluate(
+            "jira_create_issue", {"project_key": "SAFE"}, tainted=True
+        )
+        self.assertEqual(d.decision, "ALLOW")
+
+    # --- DENY: argument rules ---
+
+    def test_deny_arg_rule_disallowed_value(self):
+        d = self._engine().evaluate(
+            "jira_create_issue", {"project_key": "PROD"}, tainted=False
+        )
+        self.assertEqual(d.decision, "DENY")
+        self.assertEqual(d.rule, "jira_create_restricted_projects")
+
+    def test_allow_arg_rule_allowed_value(self):
+        d = self._engine().evaluate(
+            "jira_create_issue", {"project_key": "SAFE"}, tainted=False
+        )
+        self.assertEqual(d.decision, "ALLOW")
+
+    def test_deny_arg_rule_missing_arg(self):
+        # Missing arg → value is None, not in allowed_values → DENY
+        d = self._engine().evaluate("jira_create_issue", {}, tainted=False)
+        self.assertEqual(d.decision, "DENY")
+
+    def test_no_arg_rules_for_tool_allows(self):
+        d = self._engine().evaluate("jira_read_issue", {"issue_key": "PROJ-1"}, tainted=False)
+        self.assertEqual(d.decision, "ALLOW")
+
+    # --- ALLOW default ---
+
+    def test_allow_default(self):
+        d = self._engine().evaluate(
+            "jira_create_issue", {"project_key": "TEST"}, tainted=False
+        )
+        self.assertEqual(d.decision, "ALLOW")
+        self.assertEqual(d.rule, "default_allow")
+
+    # --- PolicyDecision is frozen ---
+
+    def test_policy_decision_frozen(self):
+        d = PolicyDecision("ALLOW", "default_allow", "tool", False)
+        with self.assertRaises(Exception):
+            d.decision = "DENY"  # type: ignore[misc]
+
+    # --- from_yaml ---
+
+    def test_from_yaml_loads_manifest(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        ) as f:
+            import yaml
+            yaml.dump(_MANIFEST, f)
+            path = Path(f.name)
+        try:
+            engine = ManifestPolicyEngine.from_yaml(path)
+            d = engine.evaluate("jira_bulk_delete", {}, tainted=False)
+            self.assertEqual(d.decision, "ABSENT")
+        finally:
+            path.unlink()
+
+    def test_from_yaml_loads_real_atlassian_manifest(self):
+        manifest_path = Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
+        engine = ManifestPolicyEngine.from_yaml(manifest_path)
+        self.assertEqual(
+            engine.evaluate("jira_read_issue", {}, tainted=False).decision, "ALLOW"
+        )
+        self.assertEqual(
+            engine.evaluate("jira_bulk_delete", {}, tainted=False).decision, "ABSENT"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: policy wired into MCPPassthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPassthroughPolicyEnforcement(unittest.TestCase):
+    def _make(self, source_channel="cli"):
+        cfg = AtlassianProxyConfig(
+            upstream_url="", mode="proxy", source_channel=source_channel
+        )
+        policy = ManifestPolicyEngine(_MANIFEST)
+        return MCPPassthrough(cfg, policy=policy)
+
+    def test_absent_tool_returns_rpc_error(self):
+        pt = self._make()
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "jira_bulk_delete", "arguments": {}},
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["decision"], "ABSENT")
+        self.assertIn("does not exist", resp["error"]["message"])
+
+    def test_deny_returns_rpc_error_with_rule(self):
+        pt = self._make()
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {"project_key": "PROD"}},
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["decision"], "DENY")
+        self.assertEqual(resp["error"]["data"]["rule"], "jira_create_restricted_projects")
+
+    def test_tainted_channel_blocks_write(self):
+        pt = self._make(source_channel="web")
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {"project_key": "SAFE"}},
+        })
+        self.assertIn("error", resp)
+        self.assertEqual(resp["error"]["data"]["decision"], "DENY")
+        self.assertEqual(resp["error"]["data"]["rule"], "tainted_source_blocks_external_write")
+
+    def test_allowed_call_proceeds_to_stub(self):
+        pt = self._make()
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "jira_create_issue", "arguments": {"project_key": "SAFE"}},
+        })
+        # No policy error; stub returns isError=True (no upstream) not a policy block
+        self.assertNotIn("error", resp)
+        self.assertTrue(resp["result"]["isError"])
+
+    def test_no_policy_always_forwards(self):
+        cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+        pt = MCPPassthrough(cfg)
+        resp = pt.forward({
+            "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": {"name": "jira_bulk_delete", "arguments": {}},
+        })
+        # No policy → stub response (not a policy block)
+        self.assertNotIn("error", resp)
+
+    def test_policy_decision_logged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "log.jsonl"
+            cfg = AtlassianProxyConfig(upstream_url="", mode="proxy")
+            policy = ManifestPolicyEngine(_MANIFEST)
+            pt = MCPPassthrough(cfg, log_path=log_path, policy=policy)
+            pt.forward({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "jira_bulk_delete", "arguments": {}},
+            })
+            entries = [json.loads(l) for l in log_path.read_text().splitlines()]
+            decision_entries = [e for e in entries if e.get("direction") == "decision"]
+            self.assertEqual(len(decision_entries), 1)
+            self.assertEqual(decision_entries[0]["decision"], "ABSENT")
+            self.assertEqual(decision_entries[0]["rule"], "tool_not_allowlisted")
+
+    def test_config_from_env_manifest_path(self):
+        manifest_path = str(
+            Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
+        )
+        with patch.dict(os.environ, {"ATLASSIAN_MANIFEST_PATH": manifest_path}):
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertIsNotNone(cfg.manifest_path)
+        self.assertEqual(cfg.manifest_path, Path(manifest_path))
+
+    def test_config_from_env_source_channel(self):
+        with patch.dict(os.environ, {"ATLASSIAN_SOURCE_CHANNEL": "web"}):
+            cfg = AtlassianProxyConfig.from_env()
+        self.assertEqual(cfg.source_channel, "web")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlassian_policy.py
+++ b/tests/test_atlassian_policy.py
@@ -127,7 +127,7 @@ class TestManifestPolicyEngine(unittest.TestCase):
         manifest_path = Path(__file__).resolve().parents[1] / "manifests" / "atlassian_mvp.yaml"
         engine = ManifestPolicyEngine.from_yaml(manifest_path)
         self.assertEqual(
-            engine.evaluate("jira_read_issue", {}, tainted=False).decision, "ALLOW"
+            engine.evaluate("jira_get_issue", {}, tainted=False).decision, "ALLOW"
         )
         self.assertEqual(
             engine.evaluate("jira_bulk_delete", {}, tainted=False).decision, "ABSENT"


### PR DESCRIPTION
Change selection from lowest to highest EPIC number so EPIC 9
(Atlassian: Jira + Confluence) is returned before EPIC 8 (Gemini).
Also fix stale open/closed EPIC range comments.

https://claude.ai/code/session_01NjSQCoDXNCN6D6gAgj9wVr