### PR TITLE
feat(epic-8): add Gemini tool call adapter (#87)

### DIFF
--- a/safe_mcp_proxy/integrations/gemini_adapter.py
+++ b/safe_mcp_proxy/integrations/gemini_adapter.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+class GeminiAdapterError(ValueError):
+    """Raised when a Gemini request cannot be parsed."""
+
+    def __init__(self, missing_field: str) -> None:
+        self.field = missing_field
+        super().__init__(f"Invalid Gemini request: missing or invalid field '{missing_field}'")
+
+
+@dataclass
+class ToolCall:
+    """Normalised representation of a Gemini function call."""
+
+    tool_name: str
+    arguments: Dict[str, Any]
+    session_id: Optional[str]
+    agent_id: Optional[str]
+    metadata: Dict[str, Any]
+    raw_request: Dict[str, Any]
+
+
+class GeminiAdapter:
+    """Stateless adapter between Gemini function-call JSON and internal ToolCall."""
+
+    @classmethod
+    def parse(cls, request: Dict[str, Any]) -> ToolCall:
+        """Convert a raw Gemini request dict to a ToolCall.
+
+        Raises GeminiAdapterError if required fields are absent or malformed.
+        Does not execute or validate against any policy.
+        """
+        if not isinstance(request, dict):
+            raise GeminiAdapterError("request")
+
+        function_call = request.get("functionCall")
+        if function_call is None:
+            raise GeminiAdapterError("functionCall")
+
+        name = function_call.get("name")
+        if not name:
+            raise GeminiAdapterError("name")
+
+        arguments: Dict[str, Any] = function_call.get("args") or {}
+
+        raw_metadata: Dict[str, Any] = request.get("metadata") or {}
+        session_id: Optional[str] = raw_metadata.get("session_id")
+        agent_id: Optional[str] = raw_metadata.get("agent_id")
+
+        return ToolCall(
+            tool_name=name,
+            arguments=arguments,
+            session_id=session_id,
+            agent_id=agent_id,
+            metadata=raw_metadata,
+            raw_request=request,
+        )
+
+    @classmethod
+    def format_response(cls, tool_name: str, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Wrap a tool result in the Gemini functionResponse envelope."""
+        return {"functionResponse": {"name": tool_name, "response": result}}

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -1,0 +1,99 @@
+import unittest
+
+from safe_mcp_proxy.integrations.gemini_adapter import (
+    GeminiAdapter,
+    GeminiAdapterError,
+    ToolCall,
+)
+
+
+def _make_request(**overrides):
+    base = {
+        "functionCall": {"name": "read_file", "args": {"path": "/tmp/x"}},
+        "metadata": {"session_id": "sess_1", "agent_id": "agent_2"},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestGeminiAdapterParse(unittest.TestCase):
+
+    def test_valid_full_request(self):
+        req = _make_request()
+        tc = GeminiAdapter.parse(req)
+        self.assertIsInstance(tc, ToolCall)
+        self.assertEqual(tc.tool_name, "read_file")
+        self.assertEqual(tc.arguments, {"path": "/tmp/x"})
+        self.assertEqual(tc.session_id, "sess_1")
+        self.assertEqual(tc.agent_id, "agent_2")
+
+    def test_valid_without_metadata(self):
+        req = {"functionCall": {"name": "list_files", "args": {}}}
+        tc = GeminiAdapter.parse(req)
+        self.assertIsNone(tc.session_id)
+        self.assertIsNone(tc.agent_id)
+        self.assertEqual(tc.metadata, {})
+
+    def test_args_defaults_to_empty_dict(self):
+        req = {"functionCall": {"name": "ping"}}
+        tc = GeminiAdapter.parse(req)
+        self.assertEqual(tc.arguments, {})
+
+    def test_missing_function_call_raises(self):
+        with self.assertRaises(GeminiAdapterError) as ctx:
+            GeminiAdapter.parse({"metadata": {}})
+        self.assertEqual(ctx.exception.field, "functionCall")
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(GeminiAdapterError) as ctx:
+            GeminiAdapter.parse({"functionCall": {"args": {}}})
+        self.assertEqual(ctx.exception.field, "name")
+
+    def test_empty_name_raises(self):
+        with self.assertRaises(GeminiAdapterError) as ctx:
+            GeminiAdapter.parse({"functionCall": {"name": "", "args": {}}})
+        self.assertEqual(ctx.exception.field, "name")
+
+    def test_not_a_dict_raises(self):
+        for bad in [None, "string", 42, ["list"]]:
+            with self.subTest(bad=bad):
+                with self.assertRaises(GeminiAdapterError) as ctx:
+                    GeminiAdapter.parse(bad)
+                self.assertEqual(ctx.exception.field, "request")
+
+    def test_extra_metadata_fields_preserved(self):
+        req = _make_request(metadata={"session_id": "s", "agent_id": "a", "custom": "val"})
+        tc = GeminiAdapter.parse(req)
+        self.assertEqual(tc.metadata["custom"], "val")
+        self.assertEqual(tc.session_id, "s")
+
+    def test_raw_request_is_original(self):
+        req = _make_request()
+        tc = GeminiAdapter.parse(req)
+        self.assertIs(tc.raw_request, req)
+
+    def test_arguments_with_nested_values(self):
+        req = {"functionCall": {"name": "create_issue", "args": {"title": "Bug", "labels": ["p1", "p2"]}}}
+        tc = GeminiAdapter.parse(req)
+        self.assertEqual(tc.arguments["labels"], ["p1", "p2"])
+
+
+class TestGeminiAdapterFormatResponse(unittest.TestCase):
+
+    def test_format_response(self):
+        result = GeminiAdapter.format_response("read_file", {"content": "hello"})
+        self.assertEqual(result, {
+            "functionResponse": {
+                "name": "read_file",
+                "response": {"content": "hello"},
+            }
+        })
+
+    def test_format_response_empty_result(self):
+        result = GeminiAdapter.format_response("ping", {})
+        self.assertEqual(result["functionResponse"]["name"], "ping")
+        self.assertEqual(result["functionResponse"]["response"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces `safe_mcp_proxy/integrations/` package with a stateless
GeminiAdapter that normalises Gemini's `functionCall` JSON format into
an internal ToolCall dataclass, and wraps results back in the Gemini
`functionResponse` envelope. No policy enforcement occurs here; this is
pure parsing — the foundation for the Gemini proxy pipeline (issues
#88–#97).

https://claude.ai/code/session_011mdVPbrhtkMrNrz5KC19GM