### PR TITLE
docs: add comprehensive wiki pages for atlassian and integrations

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -54,6 +54,8 @@ Content-oriented catalog of all pages in this wiki.
 | [[src/safe_mcp_proxy/examples/index]] | `examples/` — standalone demo scripts |
 | [[src/safe_mcp_proxy/scenarios/index]] | `scenarios/` — registered, runnable test scenarios |
 | [[src/safe_mcp_proxy/policies/index]] | `policies/` — OPA Rego policy and tests |
+| [[src/safe_mcp_proxy/atlassian/index]] | `atlassian/` — Atlassian MCP passthrough subpackage |
+| [[src/safe_mcp_proxy/integrations/index]] | `integrations/` — external LLM runtime adapters |
 
 ### Other packages
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -4,6 +4,34 @@ Append-only record of ingests, queries, and maintenance operations.
 
 ---
 
+## 2026-05-01 — Full wiki sync against HEAD (6e82b9c); metadata file added
+
+Audited the entire wiki against the current codebase. Added `wiki/meta.yaml` to track commit hash and timestamp of each sync so future updates can use `git log <commit>..HEAD` to scope the diff.
+
+**New pages created (11):**
+- `wiki/src/safe_mcp_proxy/atlassian/index.md` — subpackage overview and pipeline diagram
+- `wiki/src/safe_mcp_proxy/atlassian/passthrough.md` — `MCPPassthrough` pipeline orchestrator
+- `wiki/src/safe_mcp_proxy/atlassian/policy.md` — `ManifestPolicyEngine` five-rule decision engine
+- `wiki/src/safe_mcp_proxy/atlassian/filter.md` — `CapabilityFilter` allowlist/denylist for `tools/list`
+- `wiki/src/safe_mcp_proxy/atlassian/flow.md` — `FlowContext`, `DataFlowRule`, data-label tracking
+- `wiki/src/safe_mcp_proxy/atlassian/adapters.md` — `ATLASSIAN_TOOLS` registry + `apply_safe_abstraction`
+- `wiki/src/safe_mcp_proxy/atlassian/config.md` — `AtlassianProxyConfig` and env-var loading
+- `wiki/src/safe_mcp_proxy/atlassian/trace_reader.md` — `AtlassianTraceReader`, `TraceEntry`
+- `wiki/src/safe_mcp_proxy/atlassian/cli.md` — trace log CLI inspector
+- `wiki/src/safe_mcp_proxy/integrations/index.md` — integrations subpackage overview
+- `wiki/src/safe_mcp_proxy/integrations/gemini_adapter.md` — `GeminiAdapter`, `ToolCall`
+
+**Pages updated:**
+- `wiki/src/safe_mcp_proxy/policy_engine.md` — corrected "5 rules" → "6 rules"; added `approval_required` to `__init__` symbol table; added rule 5 (ASK / approval_required) to evaluation order
+- `wiki/src/safe_mcp_proxy/index.md` — added atlassian and integrations sub-package rows
+- `wiki/index.md` — added atlassian and integrations source page rows
+- `wiki/src/tests/index.md` — expanded file table to include all 21 test files (was 6); fixed "5 decision paths" → "6 decision paths"
+
+**New file:**
+- `wiki/meta.yaml` — tracks commit hash, timestamp, branch, updated_by, coverage_note for each sync
+
+---
+
 ## 2026-04-26 — Wiki audit: EPIC 11 full coverage
 
 - Updated `wiki/src/attacks/index.md` — added `tool_chain.yaml` and `mcp_poison.json` to layout table

--- a/wiki/meta.yaml
+++ b/wiki/meta.yaml
@@ -1,0 +1,24 @@
+# Wiki metadata — tracks the last full synchronization of wiki content against source code.
+#
+# Fields:
+#   commit        — full SHA of the HEAD commit at time of update
+#   timestamp     — ISO-8601 UTC timestamp of the update
+#   branch        — branch from which HEAD was read
+#   updated_by    — model or author that performed the update
+#   coverage_note — brief summary of what was audited
+#
+# Usage:
+#   Next time a wiki update is requested, run `git log <commit>..HEAD --oneline`
+#   to see every commit that landed since the last sync, then update affected pages.
+
+last_update:
+  commit: "6e82b9c5cc9a383c3aa65b69fabee9614fe677bf"
+  timestamp: "2026-05-01T00:00:00Z"
+  branch: "main"
+  updated_by: "claude-sonnet-4-6"
+  coverage_note: >
+    Full audit against HEAD. Added wiki pages for safe_mcp_proxy/atlassian/ (9 pages),
+    safe_mcp_proxy/integrations/ (2 pages). Fixed policy_engine source page (5→6 rules,
+    approval_required constructor arg). Updated index.md, src/index.md,
+    src/safe_mcp_proxy/index.md, src/tests/index.md to reflect all modules present
+    in the codebase.

--- a/wiki/src/safe_mcp_proxy/atlassian/adapters.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/adapters.md
@@ -1,0 +1,53 @@
+# `atlassian/adapters.py`
+
+## Role
+
+Adapter registry for the Atlassian Remote MCP Server. Declares every known Jira and Confluence tool as a `ToolAdapter`; provides the `apply_safe_abstraction()` transformer that truncates raw Confluence content.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `ToolAdapter` | frozen dataclass | Per-tool metadata: `name`, `service`, `capability`, `side_effect`, `atomic`, `safe_alias` |
+| `ATLASSIAN_TOOLS` | constant | `Dict[str, ToolAdapter]` — full registry of ~22 Jira + Confluence tools |
+| `COMPOSITE_TOOLS` | constant | `List[str]` — non-atomic tools suitable for deny-list defaults |
+| `apply_safe_abstraction` | function | Applies truncation/abstraction to a `tools/call` response if a `safe_alias` is defined |
+| `_truncate_text_blocks` | function | Truncates all text content blocks to `max_chars` characters (default 500) |
+
+## `ToolAdapter` fields
+
+| Field | Type | Values |
+|-------|------|--------|
+| `service` | str | `"jira"` or `"confluence"` |
+| `capability` | str | `jira_read`, `jira_write`, `confluence_read`, `confluence_write` |
+| `side_effect` | str | `"read"` or `"write"` |
+| `atomic` | bool | False = composite / destructive (deny-list candidates) |
+| `safe_alias` | Optional[str] | Name of safe-abstraction variant; None if no abstraction defined |
+
+## Safe abstraction
+
+`confluence_get_page` has `safe_alias="confluence_get_page_summary"`. When `apply_safe_abstraction` is called:
+1. All text content blocks are truncated to 500 characters.
+2. A `_truncated: true` field is added to truncated blocks.
+3. `result._abstraction` is set to `"confluence_get_page_summary"`.
+
+The truncation prevents raw Confluence storage-format content from reaching the LLM, mitigating indirect prompt injection via wiki pages.
+
+## Composite tools (deny-list candidates by default)
+
+- `jira_bulk_create_issues`
+- `jira_delete_issue`
+
+## Depends on
+
+Nothing outside the standard library.
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — `apply_safe_abstraction()` and `ATLASSIAN_TOOLS` lookup
+- [[src/safe_mcp_proxy/atlassian/flow]] — `_OUTPUT_LABELS` is derived from tool names in this registry
+
+## See also
+
+- [[src/safe_mcp_proxy/atlassian/filter]] — uses allowlist/denylist; `COMPOSITE_TOOLS` are typical denied_tools
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/cli.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/cli.md
@@ -1,0 +1,36 @@
+# `atlassian/cli.py`
+
+## Role
+
+CLI inspector for Atlassian MCP proxy traces. Exposes three commands — `list`, `stats`, `trace` — over the Atlassian-specific JSONL audit log. Invoked via `python -m safe_mcp_proxy.atlassian.cli`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `list` (default) | Print recent decision entries with color-coded decision, tool, rule, tainted, flow labels, trace ID prefix |
+| `stats` | Print total decision count and per-decision breakdown |
+| `trace` | Print all entries (request + decision + response) for a given `--trace-id` |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--log PATH` | Path to JSONL log (default: `safe_mcp_proxy/logs/atlassian_requests.jsonl`) |
+| `--decision D` | Filter by decision: `ALLOW`, `DENY`, `ABSENT` |
+| `--tool TOOL` | Filter by tool name |
+| `--last N` | Show last N decision entries |
+| `--trace-id ID` | Trace ID for the `trace` command |
+
+## Depends on
+
+- [[src/safe_mcp_proxy/atlassian/trace_reader]] — `AtlassianTraceReader`
+
+## Used by
+
+Standalone CLI usage only; not imported by other modules.
+
+## See also
+
+- [[src/safe_mcp_proxy/atlassian/trace_reader]] — the data source
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/config.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/config.md
@@ -1,0 +1,45 @@
+# `atlassian/config.py`
+
+## Role
+
+`AtlassianProxyConfig` — runtime configuration for the Atlassian MCP passthrough. Can be constructed directly or loaded from environment variables via `from_env()`.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `AtlassianProxyConfig` | dataclass | All runtime config for `MCPPassthrough` |
+| `AtlassianProxyConfig.from_env` | classmethod | Reads all fields from environment variables |
+| `AtlassianProxyConfig.is_proxy_mode` | property | `True` when `mode == "proxy"` |
+| `AtlassianProxyConfig.capability_filter` | method | Returns a `CapabilityFilter(allowed_tools, denied_tools)` |
+
+## Fields
+
+| Field | Type | Default | Env var |
+|-------|------|---------|---------|
+| `upstream_url` | str | `""` | `ATLASSIAN_MCP_URL` |
+| `mode` | str | `"proxy"` | `ATLASSIAN_PROXY_MODE` |
+| `timeout` | int | `30` | `ATLASSIAN_MCP_TIMEOUT` |
+| `allowed_tools` | Set[str] | `set()` | `ATLASSIAN_ALLOWED_TOOLS` (comma-separated) |
+| `denied_tools` | Set[str] | `set()` | `ATLASSIAN_DENIED_TOOLS` (comma-separated) |
+| `manifest_path` | Optional[Path] | `None` | `ATLASSIAN_MANIFEST_PATH` |
+| `source_channel` | str | `"cli"` | `ATLASSIAN_SOURCE_CHANNEL` |
+| `debug` | bool | `False` | `ATLASSIAN_DEBUG` (`1`/`true`/`yes`) |
+
+## Modes
+
+- `mode="proxy"` — requests are forwarded through the safe-mcp-proxy pipeline.
+- `mode="direct"` — proxy is bypassed; clients connect to Atlassian MCP directly (config struct still used for filter).
+
+## Depends on
+
+- [[src/safe_mcp_proxy/atlassian/filter]] — `CapabilityFilter`
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — `MCPPassthrough` receives one at construction
+- `api/main.py` — builds config from env when setting up `POST /atlassian/mcp`
+
+## See also
+
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/filter.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/filter.md
@@ -1,0 +1,33 @@
+# `atlassian/filter.py`
+
+## Role
+
+`CapabilityFilter` — applies allowlist + denylist to a `tools/list` JSON-RPC response, implementing the ABSENT principle for the Atlassian path. Tools not visible to this world are silently omitted.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `CapabilityFilter` | class | Stateless filter; constructed with `allowed_tools` and `denied_tools` sets |
+| `CapabilityFilter.filter_tools` | method | Takes `list[dict]`; returns only tools visible in this world |
+| `CapabilityFilter.apply_to_list_response` | method | Deep-copies a `tools/list` response and replaces `result.tools` with the filtered list |
+
+## Semantics
+
+- A tool in `denied_tools` is always hidden (composite / unsafe tools).
+- If `allowed_tools` is non-empty: only tools in the allowlist pass through.
+- If `allowed_tools` is empty: all tools pass through (passthrough mode); only `denied_tools` are removed.
+
+## Depends on
+
+Nothing outside the standard library.
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/config]] — `AtlassianProxyConfig.capability_filter()` builds one
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — applied to `tools/list` responses
+
+## See also
+
+- [[absent-deny]] — hidden tools implement the ABSENT principle
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/flow.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/flow.md
@@ -1,0 +1,55 @@
+# `atlassian/flow.py`
+
+## Role
+
+Data-flow control (provenance lite) for the Atlassian MCP path. `FlowContext` tracks which data labels are active in a session; `DataFlowRule` encodes which labels block which tools.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `LABEL_CONFLUENCE_RAW` | constant | `"confluence_raw"` — label for un-abstracted Confluence page content |
+| `LABEL_CONFLUENCE_SUMMARY` | constant | `"confluence_summary"` — label for safe-abstracted Confluence content |
+| `FlowContext` | class | Mutable session-level set of active data labels |
+| `FlowContext.tag_output` | method | Called after a successful tool call; adds the appropriate label |
+| `FlowContext.has_label` | method | Returns True if label is active |
+| `FlowContext.active_labels` | method | Returns a copy of the current label set |
+| `FlowContext.clear` | method | Resets all labels |
+| `FlowContext.as_dict` | method | Serializes for debug output |
+| `DataFlowRule` | dataclass | `(if_label, deny_for: list[str], rule: str)` |
+| `parse_data_flow_rules` | function | Converts raw manifest YAML list → `list[DataFlowRule]` |
+
+## Label assignment
+
+| Tool | Was abstracted | Label added |
+|------|---------------|-------------|
+| `confluence_get_page` | No | `confluence_raw` |
+| `confluence_get_page` | Yes | `confluence_summary` |
+| Any other tool | — | (no label added) |
+
+## Flow rule enforcement
+
+Rules are evaluated in `ManifestPolicyEngine.evaluate()` (rule 3):
+> If `FlowContext.has_label(dfr.if_label)` and `tool_name in dfr.deny_for` → DENY.
+
+Example manifest rule that blocks raw Confluence content from flowing into Jira writes:
+```yaml
+data_flow_rules:
+  - if_label: confluence_raw
+    deny_for: [jira_create_issue, jira_update_issue]
+    rule: raw_confluence_blocks_jira_write
+```
+
+## Depends on
+
+Nothing outside the standard library.
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/policy]] — `ManifestPolicyEngine` evaluates `DataFlowRule` entries
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — `MCPPassthrough` holds and updates `FlowContext`
+
+## See also
+
+- [[provenance-taint]] — the core pipeline's taint mechanism; this is an analogous per-session label tracker
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/index.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/index.md
@@ -1,0 +1,51 @@
+# `safe_mcp_proxy/atlassian/`
+
+## Role
+
+Passthrough proxy for the Atlassian Remote MCP Server (Jira / Confluence). Enforces a separate five-rule deterministic policy engine before forwarding JSON-RPC requests upstream.
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| [[src/safe_mcp_proxy/atlassian/passthrough]] | `MCPPassthrough` — forward + policy gate + safe abstraction + flow tagging |
+| [[src/safe_mcp_proxy/atlassian/policy]] | `ManifestPolicyEngine` — five-rule decision engine (ABSENT / DENY / ALLOW) |
+| [[src/safe_mcp_proxy/atlassian/filter]] | `CapabilityFilter` — allowlist/denylist composition for `tools/list` |
+| [[src/safe_mcp_proxy/atlassian/flow]] | `FlowContext`, `DataFlowRule` — session-level data-label tracking |
+| [[src/safe_mcp_proxy/atlassian/adapters]] | `ToolAdapter`, `ATLASSIAN_TOOLS` — full Atlassian tool registry + safe abstraction transformer |
+| [[src/safe_mcp_proxy/atlassian/config]] | `AtlassianProxyConfig` — runtime config (mode, URLs, allowed/denied tools, manifest path) |
+| [[src/safe_mcp_proxy/atlassian/trace_reader]] | `AtlassianTraceReader`, `TraceEntry` — read-only JSONL audit log for Atlassian requests |
+| [[src/safe_mcp_proxy/atlassian/cli]] | CLI inspector for Atlassian trace logs (`list`, `stats`, `trace` commands) |
+
+## Pipeline (per `tools/call`)
+
+```
+Incoming JSON-RPC request
+  ↓
+Policy gate   — ManifestPolicyEngine.evaluate() → ABSENT / DENY / ALLOW
+  ↓ (ALLOW only)
+Forward       — HTTP POST to upstream, or stub if upstream not configured
+  ↓
+Safe abstraction  — confluence_get_page → title + 500-char summary
+  ↓
+Flow tagging  — FlowContext.tag_output() labels confluence_raw / confluence_summary
+  ↓
+Response returned (with optional debug flow state)
+```
+
+`tools/list` responses pass through `CapabilityFilter` to hide denied/absent tools.
+
+## World manifest
+
+`manifests/atlassian_mvp.yaml` — demonstrates:
+- `arg_rules` (argument validation)
+- Safe abstractions (Confluence page truncation)
+- Data-flow rules blocking raw Confluence → Jira write chains
+
+## See also
+
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — full pipeline orchestrator
+- [[src/safe_mcp_proxy/atlassian/policy]] — five-rule engine detail
+- [[absent-deny]] — ABSENT / DENY semantics used by this subpackage
+- [[provenance-taint]] — `TAINTED_CHANNELS` from `provenance.py` drives taint detection
+- [[audit-replay]] — `AtlassianTraceReader` provides the same read pattern as `TraceStore`

--- a/wiki/src/safe_mcp_proxy/atlassian/passthrough.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/passthrough.md
@@ -1,0 +1,55 @@
+# `atlassian/passthrough.py`
+
+## Role
+
+`MCPPassthrough` — orchestrates the full Atlassian MCP pipeline: policy gate → HTTP forward → safe abstraction → flow tagging → optional debug output. One public method: `forward(request)`.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `MCPPassthrough` | class | Stateful pipeline orchestrator. Holds config, log path, policy, and flow context. |
+| `MCPPassthrough.__init__` | method | Takes `config`, optional `log_path`, optional `policy`, optional `flow_context` |
+| `MCPPassthrough.forward` | method | Main entry point — routes any JSON-RPC method through the full pipeline |
+| `MCPPassthrough._http_forward` | method | HTTP POST to `config.upstream_url` via `urllib.request` |
+| `MCPPassthrough._stub_response` | method | Returns static stub when upstream is not configured |
+| `MCPPassthrough._log` | method | Appends JSON entry to JSONL log file |
+| `MCPPassthrough._log_decision` | method | Appends decision entry (tool, decision, rule, tainted, flow_labels, trace_id) |
+| `_blocked_response` | function | Builds JSON-RPC error response for ABSENT/DENY decisions |
+| `_error_response` | function | Builds JSON-RPC error response for upstream failures |
+
+## `forward()` logic
+
+1. Log incoming request with a fresh `trace_id`.
+2. **Policy gate** (only for `tools/call`): call `ManifestPolicyEngine.evaluate()`; if not ALLOW, return `_blocked_response` immediately.
+3. **Forward**: HTTP POST to upstream, or call `_stub_response` if unconfigured.
+4. **Safe abstraction** (only for `tools/call`): `apply_safe_abstraction()` truncates Confluence content.
+5. **Flow tagging** (only for `tools/call`): `FlowContext.tag_output()` labels the output.
+6. **Capability filter** (only for `tools/list`): `CapabilityFilter.apply_to_list_response()`.
+7. **Debug mode**: if `config.debug`, inject `_debug.flow_context` into the result.
+8. Log response and return.
+
+## Stub responses
+
+When `upstream_url` is empty or `mode != "proxy"`, stubs are returned:
+- `tools/list` → `{"tools": []}`
+- `tools/call` → error result `"Upstream not configured"`
+- `initialize` → server info with protocol version `2024-11-05`
+
+## Depends on
+
+- [[src/safe_mcp_proxy/atlassian/config]] — `AtlassianProxyConfig`
+- [[src/safe_mcp_proxy/atlassian/policy]] — `ManifestPolicyEngine`, `PolicyDecision`
+- [[src/safe_mcp_proxy/atlassian/flow]] — `FlowContext`
+- [[src/safe_mcp_proxy/atlassian/adapters]] — `apply_safe_abstraction`, `ATLASSIAN_TOOLS`
+- [[src/safe_mcp_proxy/provenance]] — `TAINTED_CHANNELS`
+
+## Used by
+
+- `api/main.py` — `POST /atlassian/mcp` endpoint
+- [[src/safe_mcp_proxy/atlassian/cli]] — CLI entrypoint for standalone inspection
+
+## See also
+
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview and pipeline diagram
+- [[absent-deny]] — blocked responses encode ABSENT vs DENY semantics

--- a/wiki/src/safe_mcp_proxy/atlassian/policy.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/policy.md
@@ -1,0 +1,73 @@
+# `atlassian/policy.py`
+
+## Role
+
+`ManifestPolicyEngine` — deterministic five-rule decision engine for the Atlassian MCP path. Separate from the core `PolicyEngine`; operates on `allowed_tools`, `external_write_tools`, `arg_rules`, and `data_flow_rules` from a manifest YAML.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `PolicyDecision` | frozen dataclass | `(decision: str, rule: str, tool: str, tainted: bool)` |
+| `ManifestPolicyEngine` | class | Stateful engine loaded from a manifest dict or YAML file |
+| `ManifestPolicyEngine.__init__` | method | Parses allowlist, external_write, arg_rules, flow config |
+| `ManifestPolicyEngine.evaluate` | method | Evaluates five rules; returns `PolicyDecision` |
+| `ManifestPolicyEngine.from_yaml` | classmethod | Convenience constructor: reads YAML file → `cls(manifest)` |
+
+## `evaluate()` rule order
+
+```
+1. tool_name not in allowlist (if allowlist non-empty)
+   → ABSENT / tool_not_allowlisted
+
+2. tainted source + tool in external_write_tools
+   → DENY / tainted_source_blocks_external_write
+
+3. FlowContext has data-flow label that denies this tool
+   → DENY / <data_flow_rule_name>
+
+4. Argument rule violated (arg value not in allowed_values)
+   → DENY / <rule_name from manifest>
+
+5. Default
+   → ALLOW / default_allow
+```
+
+Note: if `allowed_tools` is empty in the manifest, rule 1 is skipped (passthrough mode — all tools visible).
+
+## `evaluate()` signature
+
+```python
+def evaluate(
+    self,
+    tool_name: str,
+    arguments: Dict[str, Any],
+    tainted: bool,
+    flow_context: Optional[FlowContext] = None,
+) -> PolicyDecision
+```
+
+## Manifest keys consumed
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `allowed_tools` | list[str] | Allowlist; empty = passthrough |
+| `external_write_tools` | list[str] | Tools blocked when source is tainted |
+| `arg_rules` | dict[tool → list[rule]] | Per-argument allowed_values constraints |
+| `flow_rules.tainted_source_blocks_external_write` | bool | Global enable/disable for rule 2 (default: true) |
+| `data_flow_rules` | list[DataFlowRule dicts] | Provenance-lite label constraints |
+
+## Depends on
+
+- [[src/safe_mcp_proxy/atlassian/flow]] — `DataFlowRule`, `parse_data_flow_rules`, `FlowContext`
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/passthrough]] — instantiated and consulted on every `tools/call`
+- `api/main.py` — passes manifest path when building `MCPPassthrough`
+
+## See also
+
+- [[absent-deny]] — ABSENT and DENY semantics
+- [[provenance-taint]] — taint concept mirrors core pipeline rule 4
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/atlassian/trace_reader.md
+++ b/wiki/src/safe_mcp_proxy/atlassian/trace_reader.md
@@ -1,0 +1,42 @@
+# `atlassian/trace_reader.py`
+
+## Role
+
+Read-only interface over the Atlassian-specific JSONL audit log (`safe_mcp_proxy/logs/atlassian_requests.jsonl`). Provides filtering and statistics analogous to the core `TraceStore` but scoped to Atlassian request/decision/response entries.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `TraceEntry` | dataclass | One JSONL line: `direction`, `timestamp`, `trace_id`, `payload`, `tool`, `decision`, `rule`, `tainted`, `flow_labels` |
+| `TraceEntry.from_dict` | classmethod | Parses a raw JSONL dict → `TraceEntry` |
+| `TraceEntry.as_dict` | method | Serializes back to dict (drops `payload` for compact representation) |
+| `AtlassianTraceReader` | class | Read-only log reader; accepts a `log_path: Path` |
+| `AtlassianTraceReader.all` | method | Returns all entries; returns `[]` if file does not exist |
+| `AtlassianTraceReader.decisions` | method | Filters to `direction == "decision"` entries only |
+| `AtlassianTraceReader.by_trace` | method | Returns all entries for a given `trace_id` |
+| `AtlassianTraceReader.filter` | method | Filter decisions by `decision`, `tool`, `last N` |
+| `AtlassianTraceReader.stats` | method | Returns `{"total": int, "counts": dict}` of decision counts |
+
+## Entry directions
+
+| Direction | Meaning |
+|-----------|---------|
+| `"request"` | Incoming JSON-RPC request payload |
+| `"decision"` | Policy decision (tool, decision, rule, tainted, flow_labels, trace_id) |
+| `"response"` | Outgoing JSON-RPC response payload |
+
+## Depends on
+
+Nothing outside the standard library.
+
+## Used by
+
+- [[src/safe_mcp_proxy/atlassian/cli]] — feeds `AtlassianTraceReader` to CLI commands
+- `api/main.py` — exposes trace data via `GET /atlassian/traces` (if wired)
+
+## See also
+
+- [[src/safe_mcp_proxy/trace_store]] — analogous core module
+- [[audit-replay]] — audit log format and conventions
+- [[src/safe_mcp_proxy/atlassian/index]] — subpackage overview

--- a/wiki/src/safe_mcp_proxy/index.md
+++ b/wiki/src/safe_mcp_proxy/index.md
@@ -32,6 +32,8 @@ The core enforcement package. All policy logic, tool registry, provenance tracki
 | [[src/safe_mcp_proxy/examples/index]] | Standalone demo scripts |
 | [[src/safe_mcp_proxy/scenarios/index]] | Registered, runnable test scenarios |
 | [[src/safe_mcp_proxy/policies/index]] | OPA Rego policy files |
+| [[src/safe_mcp_proxy/atlassian/index]] | Atlassian MCP passthrough — policy, filter, flow, adapters, trace reader, CLI |
+| [[src/safe_mcp_proxy/integrations/index]] | External LLM runtime adapters (Gemini function-call format) |
 
 ## Logs
 

--- a/wiki/src/safe_mcp_proxy/integrations/gemini_adapter.md
+++ b/wiki/src/safe_mcp_proxy/integrations/gemini_adapter.md
@@ -1,0 +1,43 @@
+# `integrations/gemini_adapter.py`
+
+## Role
+
+Stateless adapter that converts a Gemini `functionCall` JSON envelope into a normalized `ToolCall` dataclass and formats results back into the Gemini `functionResponse` envelope. No policy evaluation or I/O.
+
+## Key symbols
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `GeminiAdapterError` | exception | Raised when a required field is missing or malformed; carries `.field` attribute |
+| `ToolCall` | dataclass | Normalized tool request: `tool_name`, `arguments`, `session_id`, `agent_id`, `metadata`, `raw_request` |
+| `GeminiAdapter` | class | Stateless adapter; all methods are classmethods |
+| `GeminiAdapter.parse` | classmethod | `request: dict → ToolCall`; raises `GeminiAdapterError` on bad input |
+| `GeminiAdapter.format_response` | classmethod | `(tool_name, result) → {"functionResponse": {"name": ..., "response": ...}}` |
+
+## `parse()` behavior
+
+Input shape expected:
+```json
+{
+  "functionCall": {"name": "<tool_name>", "args": {...}},
+  "metadata": {"session_id": "...", "agent_id": "..."}
+}
+```
+
+- `functionCall` is required; missing → `GeminiAdapterError("functionCall")`
+- `functionCall.name` is required; empty → `GeminiAdapterError("name")`
+- `functionCall.args` defaults to `{}` if absent or null
+- `metadata` is optional; `session_id` and `agent_id` are extracted if present
+
+## Depends on
+
+Nothing outside the standard library.
+
+## Used by
+
+Not yet wired into the executor; intended for use when a Gemini-hosted agent routes tool calls through the proxy. Tests in `tests/test_gemini_adapter.py`.
+
+## See also
+
+- [[src/safe_mcp_proxy/integrations/index]] — integrations subpackage overview
+- [[src/safe_mcp_proxy/executor]] — downstream consumer of normalized tool calls

--- a/wiki/src/safe_mcp_proxy/integrations/index.md
+++ b/wiki/src/safe_mcp_proxy/integrations/index.md
@@ -1,0 +1,20 @@
+# `safe_mcp_proxy/integrations/`
+
+## Role
+
+Adapter layer for external LLM runtimes. Converts provider-specific function-call formats into the internal `ToolCall` representation used by the proxy pipeline.
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| [[src/safe_mcp_proxy/integrations/gemini_adapter]] | `GeminiAdapter` — stateless parser for Gemini `functionCall` JSON |
+
+## Design principle
+
+Adapters are stateless and do not execute or validate tool calls against policy. They only normalize the wire format so that any upstream caller can feed requests into the executor without being aware of provider-specific JSON shapes.
+
+## See also
+
+- [[src/safe_mcp_proxy/executor]] — the executor receives normalized `ToolCall` objects
+- [[src/safe_mcp_proxy/index]] — parent package overview

--- a/wiki/src/safe_mcp_proxy/policy_engine.md
+++ b/wiki/src/safe_mcp_proxy/policy_engine.md
@@ -2,16 +2,16 @@
 
 ## Role
 
-Pure Python decision logic. Takes 5 inputs, evaluates 5 ordered rules, returns a `PolicyResult`. No side effects, no I/O.
+Pure Python decision logic. Takes 5 inputs, evaluates 6 ordered rules, returns a `PolicyResult`. No side effects, no I/O.
 
 ## Key symbols
 
 | Name | Kind | Description |
 |------|------|-------------|
 | `PolicyResult` | frozen dataclass | `(decision: Decision, rule_hit: str)` |
-| `PolicyEngine` | class | Stateful engine holding the allowlist and capability_map |
-| `PolicyEngine.__init__` | method | Takes `allowlist: Iterable[str]`, `capability_map: Dict[str, bool]` |
-| `PolicyEngine.decide` | method | Evaluates 5 rules and returns `PolicyResult` |
+| `PolicyEngine` | class | Stateful engine holding the allowlist, capability_map, and approval_required set |
+| `PolicyEngine.__init__` | method | Takes `allowlist: Iterable[str]`, `capability_map: Dict[str, bool]`, `approval_required: Iterable[str] = ()` |
+| `PolicyEngine.decide` | method | Evaluates 6 rules and returns `PolicyResult` |
 
 ## `decide()` signature
 
@@ -33,7 +33,8 @@ def decide(
 2. not self.capability_map.get(capability)  → ABSENT / capability_not_allowed
 3. not descriptor_hash_valid                → DENY   / descriptor_drift
 4. taint and side_effect_type == "external" → DENY   / tainted_external_side_effect
-5. (default)                                → ALLOW  / default_allow
+5. capability in self.approval_required     → ASK    / approval_required
+6. (default)                                → ALLOW  / default_allow
 ```
 
 ## Depends on

--- a/wiki/src/tests/index.md
+++ b/wiki/src/tests/index.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-Test suite for the proxy pipeline, API layer, OPA engine, trace store, and scenarios.
+Test suite for the proxy pipeline, API layer, OPA engine, trace store, scenarios, Atlassian integration, Gemini adapter, and skill subsystem.
 
 ## Files
 
@@ -14,6 +14,21 @@ Test suite for the proxy pipeline, API layer, OPA engine, trace store, and scena
 | `test_trace_store.py` | `TraceStore` filtering and streaming |
 | `test_scenarios.py` | Named scenario registration and execution |
 | `test_run_demo.py` | `run_demo.py` smoke test |
+| `test_attack_corpus.py` | Attack corpus loader and scenario validation |
+| `test_mcpzero.py` | MCPZero demo pipeline — baseline vs protected mode |
+| `test_capability_projection.py` | `CapabilityProjectionEngine` filtering rules |
+| `test_skill_registry.py` | `SkillSourceRegistry` import and catalogue |
+| `test_skill_execution_guard.py` | Executor skill execution guard (7-step constraint check) |
+| `test_skill_manifest.py` | Skill capability manifest parsing and validation |
+| `test_skill_trace.py` | Skill execution audit trace fields |
+| `test_gemini_adapter.py` | `GeminiAdapter.parse()` and `format_response()` |
+| `test_atlassian_policy.py` | `ManifestPolicyEngine` five-rule decision logic |
+| `test_atlassian_filter.py` | `CapabilityFilter` allowlist/denylist composition |
+| `test_atlassian_flow.py` | `FlowContext` label tracking and data-flow rules |
+| `test_atlassian_passthrough.py` | `MCPPassthrough` full pipeline (stub mode) |
+| `test_atlassian_adapters.py` | `ATLASSIAN_TOOLS` registry + `apply_safe_abstraction` |
+| `test_atlassian_demo.py` | Atlassian attack-and-block integration demo |
+| `test_atlassian_observability.py` | `AtlassianTraceReader` filtering and stats |
 
 ## Running tests
 
@@ -48,7 +63,7 @@ Key test cases:
 
 - [[audit-replay]] — replay test patterns
 - [[absent-deny]] — the outcomes being tested
-- [[policy-engine]] — test cases cover all 5 decision paths
+- [[policy-engine]] — test cases cover all 6 decision paths
 - [[world-manifest]] — `TestMultipleWorlds` tests cross-world policy variation
 - [[provenance-taint]] — `test_tainted_external_is_denied` tests taint rule directly
 - [[descriptor-drift]] — `test_descriptor_drift_is_denied` tests schema mutation detection


### PR DESCRIPTION
## Summary

This PR adds comprehensive wiki documentation for the Atlassian MCP proxy subpackage and the new integrations layer. The changes include 11 new wiki pages documenting the complete Atlassian pipeline, policy engine, data-flow control, and the Gemini adapter integration. Additionally, existing pages are updated to reflect the full scope of the codebase.

## Key Changes

**New Documentation (11 pages):**
- `wiki/src/safe_mcp_proxy/atlassian/index.md` — Subpackage overview with pipeline diagram showing policy gate → forward → safe abstraction → flow tagging flow
- `wiki/src/safe_mcp_proxy/atlassian/passthrough.md` — `MCPPassthrough` orchestrator documenting the 8-step request processing pipeline
- `wiki/src/safe_mcp_proxy/atlassian/policy.md` — `ManifestPolicyEngine` five-rule decision engine (allowlist check, tainted source blocking, data-flow rules, argument validation, default allow)
- `wiki/src/safe_mcp_proxy/atlassian/filter.md` — `CapabilityFilter` for allowlist/denylist composition on `tools/list` responses
- `wiki/src/safe_mcp_proxy/atlassian/flow.md` — `FlowContext` and `DataFlowRule` for session-level data-label tracking (confluence_raw vs confluence_summary)
- `wiki/src/safe_mcp_proxy/atlassian/adapters.md` — `ATLASSIAN_TOOLS` registry (~22 Jira/Confluence tools) and `apply_safe_abstraction()` transformer for Confluence content truncation
- `wiki/src/safe_mcp_proxy/atlassian/config.md` — `AtlassianProxyConfig` runtime configuration with environment variable loading
- `wiki/src/safe_mcp_proxy/atlassian/trace_reader.md` — `AtlassianTraceReader` for reading Atlassian-specific JSONL audit logs
- `wiki/src/safe_mcp_proxy/atlassian/cli.md` — CLI inspector for Atlassian traces (list, stats, trace commands)
- `wiki/src/safe_mcp_proxy/integrations/index.md` — Integrations subpackage overview
- `wiki/src/safe_mcp_proxy/integrations/gemini_adapter.md` — `GeminiAdapter` stateless parser for Gemini `functionCall` JSON format

**Updated Documentation:**
- `wiki/src/safe_mcp_proxy/policy_engine.md` — Corrected rule count from 5 to 6; added `approval_required` parameter to `__init__`; documented rule 5 (ASK / approval_required)
- `wiki/src/safe_mcp_proxy/index.md` — Added atlassian and integrations subpackage rows to module table
- `wiki/index.md` — Added atlassian and integrations source page rows
- `wiki/src/tests/index.md` — Expanded test file table from 6 to 21 files; updated decision path count from 5 to 6

**New Metadata:**
- `wiki/meta.yaml` — Tracks last full wiki synchronization (commit hash, timestamp, branch, coverage notes) to enable incremental updates via `git log <commit>..HEAD`

**Updated Log:**
- `wiki/log.md` — Added entry documenting this full wiki sync operation

## Notable Implementation Details

- The Atlassian policy engine is documented as a separate, deterministic five-rule system distinct from the core `PolicyEngine` (which has six rules)
- Safe abstraction for Confluence content is documented as truncating text blocks to 500 characters to prevent indirect prompt injection
- Data-flow rules implement a provenance-lite label system (confluence_raw vs confluence_summary) that blocks certain tool chains
- The `GeminiAdapter` is documented as stateless and format-only; it does not perform policy evaluation
- Wiki metadata file enables future incremental updates by tracking the commit hash of the last full sync

https://claude.ai/code/session_011KsCTUaoNwJ6Sz7CoSjWxb