### PR TITLE
feat(gemini): add passthrough proxy endpoint (EPIC 8 / Issue #88)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -269,6 +269,11 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     # Gemini integration (EPIC 8 / Phase 1 passthrough)
     # ------------------------------------------------------------------
 
+    @app.get("/integrations/gemini/tools/list")
+    async def gemini_list_tools() -> dict:
+        """Return the manifest-filtered tool surface in Gemini function-declaration format."""
+        return app.state.gemini_proxy.list_tools()
+
     @app.post("/integrations/gemini/tools/execute")
     async def gemini_execute(request: Any = Body(...)) -> dict:
         """Accept a Gemini functionCall request and route it through the proxy."""

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,8 @@ import safe_mcp_proxy.scenarios as _scenarios
 from safe_mcp_proxy.compiler import compile_world_manifest
 from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter, GeminiAdapterError
+from safe_mcp_proxy.integrations.gemini_proxy import GeminiProxy
 from safe_mcp_proxy.main import build_executor
 from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.trace_store import TraceStore
@@ -66,6 +68,7 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     app = FastAPI(title="safe-mcp-proxy API")
     app.state.trace_store = _build_trace_store(resolved_base_dir)
     app.state.executor = executor or build_executor(resolved_base_dir)
+    app.state.gemini_proxy = GeminiProxy(app.state.executor)
 
     app.add_middleware(
         CORSMiddleware,
@@ -261,6 +264,18 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
             "manifest_configured": cfg.manifest_path is not None,
             "source_channel": cfg.source_channel,
         }
+
+    # ------------------------------------------------------------------
+    # Gemini integration (EPIC 8 / Phase 1 passthrough)
+    # ------------------------------------------------------------------
+
+    @app.post("/integrations/gemini/tools/execute")
+    async def gemini_execute(request: Any = Body(...)) -> dict:
+        """Accept a Gemini functionCall request and route it through the proxy."""
+        try:
+            return app.state.gemini_proxy.execute(request)
+        except GeminiAdapterError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
 
     return app
 

--- a/safe_mcp_proxy/executor.py
+++ b/safe_mcp_proxy/executor.py
@@ -380,6 +380,23 @@ class Executor:
             "matches": matches,
         }
 
+    def record_absence(
+        self,
+        tool_name: str,
+        rule: str,
+        source_channel: str,
+        taint: bool = False,
+    ) -> None:
+        """Log an ABSENT decision to the audit trail without executing anything."""
+        self._audit(
+            tool=tool_name,
+            decision="ABSENT",
+            rule=rule,
+            taint=taint,
+            descriptor_hash="",
+            source_channel=source_channel,
+        )
+
     def _audit(
         self,
         tool: str,

--- a/safe_mcp_proxy/integrations/execution_spec.py
+++ b/safe_mcp_proxy/integrations/execution_spec.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from safe_mcp_proxy.decision import Decision
+from safe_mcp_proxy.integrations.intent_ir import IntentIR
+from safe_mcp_proxy.provenance import Provenance
+
+
+@dataclass(frozen=True)
+class ExecutionSpec:
+    """Typed policy-evaluation result for a single Gemini tool invocation.
+
+    Produced by GeminiPolicyGate.evaluate() after consulting the PolicyEngine.
+    Sits between IntentIR mapping and execution routing (Issue #93).
+
+    Fields:
+        decision  — ALLOW / DENY / ABSENT / ASK
+        rule      — the specific rule that produced the decision
+        intent    — the resolved IntentIR this spec was built from
+        provenance — taint / source / mode context that influenced the decision
+    """
+
+    decision: Decision
+    rule: str
+    intent: IntentIR
+    provenance: Provenance

--- a/safe_mcp_proxy/integrations/gemini_policy_gate.py
+++ b/safe_mcp_proxy/integrations/gemini_policy_gate.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from safe_mcp_proxy.descriptor import descriptor_hash_valid
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.integrations.execution_spec import ExecutionSpec
+from safe_mcp_proxy.integrations.intent_ir import IntentIR
+from safe_mcp_proxy.provenance import Provenance
+
+
+class GeminiPolicyGate:
+    """Evaluates an IntentIR against the world manifest policy and returns an ExecutionSpec.
+
+    Reuses the executor's PolicyEngine and registry — no logic is duplicated.
+    Descriptor drift is detected by comparing the current schema hash against
+    the hash recorded at registration time.
+
+    This stage sits between IntentMapper (Issue #90) and execution routing
+    (Issue #93). Its output, ExecutionSpec, carries the decision and all
+    context needed for routing.
+    """
+
+    def __init__(self, executor: Executor) -> None:
+        self._policy = executor.policy_engine
+        self._registry = executor.registry
+
+    def evaluate(self, intent: IntentIR, provenance: Provenance) -> ExecutionSpec:
+        """Run policy evaluation for intent and return a typed ExecutionSpec.
+
+        Uses the allowlist-filtered registry (get_tool) so that non-allowlisted
+        tools are correctly caught by the tool_not_allowlisted rule.
+        """
+        tool = self._registry.get_tool(intent.action)
+        hash_ok = (
+            descriptor_hash_valid(tool.schema, tool.descriptor_hash)
+            if tool is not None
+            else True
+        )
+        capability = (
+            intent.required_capabilities[0]
+            if intent.required_capabilities
+            else intent.action
+        )
+
+        policy_result = self._policy.decide(
+            tool_name=intent.action,
+            capability=capability,
+            taint=provenance.tainted,
+            side_effect_type=intent.side_effect_type,
+            descriptor_hash_valid=hash_ok,
+        )
+
+        return ExecutionSpec(
+            decision=policy_result.decision,
+            rule=policy_result.rule_hit,
+            intent=intent,
+            provenance=provenance,
+        )

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter
+from safe_mcp_proxy.provenance import Provenance
+
+
+class GeminiProxy:
+    """Routes a Gemini function-call request through the executor pipeline.
+
+    Phase 1 passthrough: parses the request, picks a source channel from the
+    request metadata (defaults to "web"), and delegates to the executor which
+    handles policy enforcement and audit logging.
+    """
+
+    def __init__(self, executor: Executor) -> None:
+        self._executor = executor
+
+    def execute(self, request: dict) -> dict:
+        tool_call = GeminiAdapter.parse(request)
+        source = tool_call.metadata.get("source_channel", "web")
+        provenance = Provenance.from_source(source)
+        result = self._executor.execute(
+            tool_call.tool_name, tool_call.arguments, provenance
+        )
+        return GeminiAdapter.format_response(tool_call.tool_name, result)

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -2,27 +2,38 @@ from __future__ import annotations
 
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter
+from safe_mcp_proxy.integrations.intent_ir import IntentIRError, IntentMapper
 from safe_mcp_proxy.provenance import Provenance
 
 
 class GeminiProxy:
     """Routes a Gemini function-call request through the executor pipeline.
 
-    Phase 1 passthrough: parses the request, picks a source channel from the
-    request metadata (defaults to "web"), and delegates to the executor which
-    handles policy enforcement and audit logging.
+    Request flow:
+        GeminiAdapter.parse()  →  ToolCall
+        IntentMapper.map()     →  IntentIR  (raises IntentIRError if unknown)
+        executor.execute()     →  policy decision + audit log
+        GeminiAdapter.format_response()  →  Gemini envelope
     """
 
     def __init__(self, executor: Executor) -> None:
         self._executor = executor
+        self._mapper = IntentMapper(executor.registry)
 
     def execute(self, request: dict) -> dict:
         tool_call = GeminiAdapter.parse(request)
         source = tool_call.metadata.get("source_channel", "web")
         provenance = Provenance.from_source(source)
-        result = self._executor.execute(
-            tool_call.tool_name, tool_call.arguments, provenance
-        )
+
+        try:
+            intent = self._mapper.map(tool_call)
+        except IntentIRError:
+            # Action is not registered anywhere in the system — ontological absence.
+            # Return a structured ABSENT response without touching the executor.
+            result = {"decision": "ABSENT", "rule": "action_not_in_ontology", "result": None}
+            return GeminiAdapter.format_response(tool_call.tool_name, result)
+
+        result = self._executor.execute(intent.action, intent.parameters, provenance)
         return GeminiAdapter.format_response(tool_call.tool_name, result)
 
     def list_tools(self) -> dict:

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -24,3 +24,17 @@ class GeminiProxy:
             tool_call.tool_name, tool_call.arguments, provenance
         )
         return GeminiAdapter.format_response(tool_call.tool_name, result)
+
+    def list_tools(self) -> dict:
+        """Return the manifest-filtered tool surface in Gemini function-declaration format.
+
+        Only tools in the world allowlist are visible — absent tools are not
+        mentioned, consistent with the ABSENT principle.
+        """
+        tools = self._executor.registry.list_exposed()
+        return {
+            "tools": [
+                {"name": tool.name, "parameters": tool.schema}
+                for tool in tools
+            ]
+        }

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -7,15 +7,19 @@ from safe_mcp_proxy.integrations.gemini_policy_gate import GeminiPolicyGate
 from safe_mcp_proxy.integrations.intent_ir import IntentIRError, IntentMapper
 from safe_mcp_proxy.provenance import Provenance
 
+_ABSENCE_MESSAGE = "Action does not exist in this world"
+
 
 class GeminiProxy:
     """Routes a Gemini function-call request through the executor pipeline.
 
     Request flow:
-        GeminiAdapter.parse()      →  ToolCall
-        IntentMapper.map()         →  IntentIR   (IntentIRError if unknown)
-        GeminiPolicyGate.evaluate()→  ExecutionSpec
-        executor.execute()         →  result + audit log  (ALLOW / ASK only)
+        GeminiAdapter.parse()       →  ToolCall
+        IntentMapper.map()          →  IntentIR   (IntentIRError → ontological absence)
+        GeminiPolicyGate.evaluate() →  ExecutionSpec
+        executor.execute()          →  result + audit log  (ALLOW / ASK)
+        executor.execute()          →  ABSENT result + audit log  (allowlist miss)
+        short-circuit               →  DENY response (no execution, logged separately)
     """
 
     def __init__(self, executor: Executor) -> None:
@@ -31,19 +35,37 @@ class GeminiProxy:
         try:
             intent = self._mapper.map(tool_call)
         except IntentIRError:
-            # Action is not registered anywhere in the system.
-            result = {"decision": "ABSENT", "rule": "action_not_in_ontology", "result": None}
+            # Action is completely unknown — not in any world's catalog.
+            # Log the absence and return the canonical response.
+            self._executor.record_absence(
+                tool_name=tool_call.tool_name,
+                rule="action_not_in_ontology",
+                source_channel=provenance.source_channel,
+                taint=provenance.tainted,
+            )
+            result = {
+                "decision": "ABSENT",
+                "rule": "action_not_in_ontology",
+                "message": _ABSENCE_MESSAGE,
+                "result": None,
+            }
             return GeminiAdapter.format_response(tool_call.tool_name, result)
 
         spec = self._policy_gate.evaluate(intent, provenance)
 
-        if spec.decision in (Decision.DENY, Decision.ABSENT):
-            # Short-circuit: no execution, no audit (policy gate made the call).
-            result = {"decision": spec.decision.value, "rule": spec.rule, "result": None}
+        if spec.decision == Decision.DENY:
+            # Policy violation: short-circuit without execution.
+            # Audit logging for deny is handled in issue #95 (provenance & trace).
+            result = {
+                "decision": spec.decision.value,
+                "rule": spec.rule,
+                "message": f"Action blocked by policy: {spec.rule}",
+                "result": None,
+            }
             return GeminiAdapter.format_response(tool_call.tool_name, result)
 
-        # ALLOW / ASK: delegate to executor which handles execution, ASK token
-        # creation, and audit logging.
+        # ABSENT (allowlist miss), ALLOW, ASK: delegate to executor.
+        # The executor handles execution, ASK token creation, and audit logging.
         result = self._executor.execute(intent.action, intent.parameters, provenance)
         return GeminiAdapter.format_response(tool_call.tool_name, result)
 

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter
+from safe_mcp_proxy.integrations.gemini_policy_gate import GeminiPolicyGate
 from safe_mcp_proxy.integrations.intent_ir import IntentIRError, IntentMapper
 from safe_mcp_proxy.provenance import Provenance
 
@@ -10,15 +12,16 @@ class GeminiProxy:
     """Routes a Gemini function-call request through the executor pipeline.
 
     Request flow:
-        GeminiAdapter.parse()  →  ToolCall
-        IntentMapper.map()     →  IntentIR  (raises IntentIRError if unknown)
-        executor.execute()     →  policy decision + audit log
-        GeminiAdapter.format_response()  →  Gemini envelope
+        GeminiAdapter.parse()      →  ToolCall
+        IntentMapper.map()         →  IntentIR   (IntentIRError if unknown)
+        GeminiPolicyGate.evaluate()→  ExecutionSpec
+        executor.execute()         →  result + audit log  (ALLOW / ASK only)
     """
 
     def __init__(self, executor: Executor) -> None:
         self._executor = executor
         self._mapper = IntentMapper(executor.registry)
+        self._policy_gate = GeminiPolicyGate(executor)
 
     def execute(self, request: dict) -> dict:
         tool_call = GeminiAdapter.parse(request)
@@ -28,11 +31,19 @@ class GeminiProxy:
         try:
             intent = self._mapper.map(tool_call)
         except IntentIRError:
-            # Action is not registered anywhere in the system — ontological absence.
-            # Return a structured ABSENT response without touching the executor.
+            # Action is not registered anywhere in the system.
             result = {"decision": "ABSENT", "rule": "action_not_in_ontology", "result": None}
             return GeminiAdapter.format_response(tool_call.tool_name, result)
 
+        spec = self._policy_gate.evaluate(intent, provenance)
+
+        if spec.decision in (Decision.DENY, Decision.ABSENT):
+            # Short-circuit: no execution, no audit (policy gate made the call).
+            result = {"decision": spec.decision.value, "rule": spec.rule, "result": None}
+            return GeminiAdapter.format_response(tool_call.tool_name, result)
+
+        # ALLOW / ASK: delegate to executor which handles execution, ASK token
+        # creation, and audit logging.
         result = self._executor.execute(intent.action, intent.parameters, provenance)
         return GeminiAdapter.format_response(tool_call.tool_name, result)
 

--- a/safe_mcp_proxy/integrations/intent_ir.py
+++ b/safe_mcp_proxy/integrations/intent_ir.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from safe_mcp_proxy.integrations.gemini_adapter import ToolCall
+from safe_mcp_proxy.registry import ToolRegistry
+
+
+class IntentIRError(KeyError):
+    """Raised when the requested action is not in the system ontology.
+
+    Distinct from ABSENT (policy blocks a *known* action) — here the action
+    is completely unknown: no tool record exists for it in the registry.
+    """
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+        super().__init__(f"Action not in ontology: {action!r}")
+
+
+@dataclass(frozen=True)
+class IntentIR:
+    """Strict intermediate representation of an agent's intent.
+
+    Sits between adapter parsing (ToolCall) and policy evaluation (executor).
+    All fields are resolved deterministically from the registry — no inference,
+    no guessing, no fallback.
+    """
+
+    action: str
+    parameters: Dict[str, Any]
+    required_capabilities: List[str]
+    side_effect_type: str
+    descriptor_hash: str
+
+
+class IntentMapper:
+    """Maps a normalised ToolCall to an IntentIR using the tool registry.
+
+    Uses the full tool catalog (not just the allowlist) to detect ontology
+    membership. A tool that exists but is not allowlisted will still produce
+    a valid IntentIR — the policy engine decides whether execution is ABSENT
+    or ALLOW/DENY. A completely unknown tool raises IntentIRError.
+    """
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+
+    def map(self, tool_call: ToolCall) -> IntentIR:
+        """Convert a ToolCall to an IntentIR.
+
+        Raises:
+            IntentIRError: if tool_call.tool_name is not registered anywhere
+                in the system (not in the full catalog, allowlisted or not).
+        """
+        tool = self._registry.get_any_tool(tool_call.tool_name)
+        if tool is None:
+            raise IntentIRError(tool_call.tool_name)
+        return IntentIR(
+            action=tool_call.tool_name,
+            parameters=tool_call.arguments,
+            required_capabilities=[tool.capability],
+            side_effect_type=tool.side_effect_type,
+            descriptor_hash=tool.descriptor_hash,
+        )

--- a/safe_mcp_proxy/registry.py
+++ b/safe_mcp_proxy/registry.py
@@ -149,6 +149,14 @@ class ToolRegistry:
         """Return all tools visible in this world (allowlist-filtered)."""
         return list(self._exposed_tools.values())
 
+    def get_any_tool(self, tool_name: str) -> Optional[Tool]:
+        """Look up a tool from the full catalog regardless of allowlist.
+
+        Used by IntentMapper to distinguish 'not in ontology' (unknown tool)
+        from 'in ontology but absent in this world' (policy decision).
+        """
+        return self._all_tools.get(tool_name)
+
     def get_tool(self, tool_name: str) -> Optional[Tool]:
         return self._exposed_tools.get(tool_name)
 

--- a/safe_mcp_proxy/registry.py
+++ b/safe_mcp_proxy/registry.py
@@ -145,6 +145,10 @@ class ToolRegistry:
 
         return cls(upstream_tools=tools, allowlist=allowlist)
 
+    def list_exposed(self) -> list[Tool]:
+        """Return all tools visible in this world (allowlist-filtered)."""
+        return list(self._exposed_tools.values())
+
     def get_tool(self, tool_name: str) -> Optional[Tool]:
         return self._exposed_tools.get(tool_name)
 

--- a/tests/test_gemini_absence.py
+++ b/tests/test_gemini_absence.py
@@ -1,0 +1,143 @@
+"""Tests for EPIC 8 Issue #92 — Ontological Absence Handling."""
+import asyncio
+import json
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import httpx
+
+from api.main import create_app
+
+_MANIFEST = textwrap.dedent("""\
+    world_id: default
+    allowed_tools: [read_file]
+    capabilities:
+      read_file: {allowed: true}
+      send_email: {allowed: true}
+    taint_rules:
+      - tainted_external: deny
+    side_effects: {external: restricted}
+""")
+
+_POLICY = "simulation:\n  external_side_effects: true\n"
+
+
+class OntologicalAbsenceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "world_manifest.yaml").write_text(_MANIFEST, encoding="utf-8")
+        cfg = self.tmp / "safe_mcp_proxy" / "config"
+        cfg.mkdir(parents=True)
+        (cfg / "policy.yaml").write_text(_POLICY, encoding="utf-8")
+        logs = self.tmp / "safe_mcp_proxy" / "logs"
+        logs.mkdir(parents=True)
+        self.audit_path = logs / "audit.jsonl"
+        self.audit_path.write_text("", encoding="utf-8")
+        self.app = create_app(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _post(self, payload: dict) -> httpx.Response:
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+                return await c.post("/integrations/gemini/tools/execute", json=payload)
+        return asyncio.run(_run())
+
+    def _audit_entries(self) -> list[dict]:
+        lines = self.audit_path.read_text(encoding="utf-8").splitlines()
+        return [json.loads(line) for line in lines if line.strip()]
+
+    # ------------------------------------------------------------------
+    # Canonical absence response
+    # ------------------------------------------------------------------
+
+    def test_unknown_tool_returns_absent_decision(self):
+        resp = self._post({"functionCall": {"name": "exfiltrate_everything", "args": {}}})
+        body = resp.json()["functionResponse"]["response"]
+        self.assertEqual(body["decision"], "ABSENT")
+
+    def test_unknown_tool_rule_is_action_not_in_ontology(self):
+        resp = self._post({"functionCall": {"name": "exfiltrate_everything", "args": {}}})
+        body = resp.json()["functionResponse"]["response"]
+        self.assertEqual(body["rule"], "action_not_in_ontology")
+
+    def test_unknown_tool_response_contains_canonical_message(self):
+        resp = self._post({"functionCall": {"name": "exfiltrate_everything", "args": {}}})
+        body = resp.json()["functionResponse"]["response"]
+        self.assertIn("message", body)
+        self.assertEqual(body["message"], "Action does not exist in this world")
+
+    def test_response_is_machine_readable_json(self):
+        resp = self._post({"functionCall": {"name": "ghost_tool", "args": {}}})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        # Top-level Gemini envelope
+        self.assertIn("functionResponse", body)
+        inner = body["functionResponse"]["response"]
+        # Machine-readable fields
+        self.assertIn("decision", inner)
+        self.assertIn("rule", inner)
+
+    def test_absent_response_is_not_a_denial(self):
+        # The absence response must NOT say "DENY" — that would imply the action is known
+        resp = self._post({"functionCall": {"name": "ghost_tool", "args": {}}})
+        body = resp.json()["functionResponse"]["response"]
+        self.assertNotEqual(body["decision"], "DENY")
+        self.assertNotIn("denied", body.get("message", "").lower())
+
+    # ------------------------------------------------------------------
+    # Audit trail
+    # ------------------------------------------------------------------
+
+    def test_ontological_absence_is_logged_to_audit(self):
+        self._post({"functionCall": {"name": "exfiltrate_everything", "args": {}}})
+        entries = self._audit_entries()
+        self.assertGreater(len(entries), 0)
+        absent_entry = next(
+            (e for e in entries if e.get("rule") == "action_not_in_ontology"), None
+        )
+        self.assertIsNotNone(absent_entry, "No audit entry with rule=action_not_in_ontology")
+
+    def test_audit_entry_has_correct_tool_name(self):
+        self._post({"functionCall": {"name": "mystery_tool", "args": {}}})
+        entries = self._audit_entries()
+        entry = next(e for e in entries if e.get("rule") == "action_not_in_ontology")
+        self.assertEqual(entry["tool"], "mystery_tool")
+
+    def test_audit_entry_decision_is_absent(self):
+        self._post({"functionCall": {"name": "mystery_tool", "args": {}}})
+        entries = self._audit_entries()
+        entry = next(e for e in entries if e.get("rule") == "action_not_in_ontology")
+        self.assertEqual(entry["decision"], "ABSENT")
+
+    def test_tainted_source_reflected_in_audit_entry(self):
+        self._post({
+            "functionCall": {"name": "mystery_tool", "args": {}},
+            "metadata": {"source_channel": "email"},
+        })
+        entries = self._audit_entries()
+        entry = next(e for e in entries if e.get("rule") == "action_not_in_ontology")
+        self.assertTrue(entry["taint"])
+
+    # ------------------------------------------------------------------
+    # Allowlist ABSENT (known tool, not in this world) still logs via executor
+    # ------------------------------------------------------------------
+
+    def test_allowlist_absent_is_also_logged(self):
+        # send_email is in the registry but not in the allowed_tools list
+        self._post({
+            "functionCall": {"name": "send_email", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        })
+        entries = self._audit_entries()
+        absent_entries = [e for e in entries if e.get("decision") == "ABSENT"]
+        self.assertGreater(len(absent_entries), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gemini_policy_gate.py
+++ b/tests/test_gemini_policy_gate.py
@@ -1,0 +1,224 @@
+"""Tests for EPIC 8 Issue #91 — Gemini Policy Enforcement Integration."""
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from safe_mcp_proxy.decision import Decision
+from safe_mcp_proxy.integrations.execution_spec import ExecutionSpec
+from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter
+from safe_mcp_proxy.integrations.gemini_policy_gate import GeminiPolicyGate
+from safe_mcp_proxy.integrations.intent_ir import IntentMapper
+from safe_mcp_proxy.main import build_executor
+from safe_mcp_proxy.provenance import Provenance
+
+
+_MANIFEST = textwrap.dedent("""\
+    world_id: default
+    allowed_tools: [read_file, send_email]
+    capabilities:
+      read_file: {allowed: true}
+      send_email: {allowed: true}
+    taint_rules:
+      - tainted_external: deny
+    side_effects: {external: restricted}
+""")
+
+_POLICY = "simulation:\n  external_side_effects: true\n"
+
+
+def _make_executor(manifest: str = _MANIFEST):
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "world_manifest.yaml").write_text(manifest, encoding="utf-8")
+    cfg = tmp / "safe_mcp_proxy" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "policy.yaml").write_text(_POLICY, encoding="utf-8")
+    (tmp / "safe_mcp_proxy" / "logs").mkdir(parents=True)
+    (tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl").write_text("", encoding="utf-8")
+    return build_executor(tmp), tmp
+
+
+def _tool_call(name: str, args: dict | None = None):
+    return GeminiAdapter.parse({"functionCall": {"name": name, "args": args or {}}})
+
+
+class ExecutionSpecTests(unittest.TestCase):
+    def test_is_frozen(self):
+        from safe_mcp_proxy.integrations.intent_ir import IntentIR
+        intent = IntentIR(
+            action="read_file", parameters={},
+            required_capabilities=["read_file"],
+            side_effect_type="read", descriptor_hash="abc",
+        )
+        prov = Provenance.from_source("cli")
+        spec = ExecutionSpec(decision=Decision.ALLOW, rule="default_allow",
+                             intent=intent, provenance=prov)
+        with self.assertRaises((AttributeError, TypeError)):
+            spec.decision = Decision.DENY  # type: ignore[misc]
+
+    def test_fields_accessible(self):
+        from safe_mcp_proxy.integrations.intent_ir import IntentIR
+        intent = IntentIR(
+            action="read_file", parameters={"path": "x"},
+            required_capabilities=["read_file"],
+            side_effect_type="read", descriptor_hash="abc",
+        )
+        prov = Provenance.from_source("cli")
+        spec = ExecutionSpec(decision=Decision.DENY, rule="descriptor_drift",
+                             intent=intent, provenance=prov)
+        self.assertIs(spec.decision, Decision.DENY)
+        self.assertEqual(spec.rule, "descriptor_drift")
+        self.assertIs(spec.intent, intent)
+        self.assertIs(spec.provenance, prov)
+
+
+class GeminiPolicyGateTests(unittest.TestCase):
+    def setUp(self):
+        self._executor, self._tmp = _make_executor()
+        self._gate = GeminiPolicyGate(self._executor)
+        self._mapper = IntentMapper(self._executor.registry)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _evaluate(self, tool_name: str, source: str = "cli",
+                  args: dict | None = None) -> ExecutionSpec:
+        tool_call = _tool_call(tool_name, args)
+        intent = self._mapper.map(tool_call)
+        provenance = Provenance.from_source(source)
+        return self._gate.evaluate(intent, provenance)
+
+    # ------------------------------------------------------------------
+    # ALLOW
+    # ------------------------------------------------------------------
+
+    def test_clean_read_file_is_allow(self):
+        spec = self._evaluate("read_file", source="cli")
+        self.assertIs(spec.decision, Decision.ALLOW)
+        self.assertEqual(spec.rule, "default_allow")
+
+    def test_returns_execution_spec_instance(self):
+        spec = self._evaluate("read_file")
+        self.assertIsInstance(spec, ExecutionSpec)
+
+    def test_spec_carries_intent_and_provenance(self):
+        spec = self._evaluate("read_file", source="cli")
+        self.assertEqual(spec.intent.action, "read_file")
+        self.assertEqual(spec.provenance.source_channel, "cli")
+
+    # ------------------------------------------------------------------
+    # DENY
+    # ------------------------------------------------------------------
+
+    def test_tainted_send_email_is_deny(self):
+        spec = self._evaluate("send_email", source="web")
+        self.assertIs(spec.decision, Decision.DENY)
+        self.assertEqual(spec.rule, "tainted_external_side_effect")
+
+    def test_tainted_email_from_tool_output_is_deny(self):
+        spec = self._evaluate("send_email", source="tool_output")
+        self.assertIs(spec.decision, Decision.DENY)
+
+    # ------------------------------------------------------------------
+    # ABSENT — allowlist miss
+    # ------------------------------------------------------------------
+
+    def test_non_allowlisted_tool_is_absent(self):
+        # dangerous_exec is in the catalog but not allowlisted
+        spec = self._evaluate("dangerous_exec", source="cli")
+        self.assertIs(spec.decision, Decision.ABSENT)
+        self.assertEqual(spec.rule, "tool_not_allowlisted")
+
+    # ------------------------------------------------------------------
+    # Descriptor drift → DENY
+    # ------------------------------------------------------------------
+
+    def test_descriptor_drift_causes_deny(self):
+        tool = self._executor.registry.get_tool("read_file")
+        original_hash = tool.descriptor_hash
+        # Mutate the stored hash to simulate drift
+        tool.descriptor_hash = "badhash"
+        spec = self._evaluate("read_file", source="cli")
+        tool.descriptor_hash = original_hash  # restore
+        self.assertIs(spec.decision, Decision.DENY)
+        self.assertEqual(spec.rule, "descriptor_drift")
+
+    # ------------------------------------------------------------------
+    # ASK — approval_required capability
+    # ------------------------------------------------------------------
+
+    def test_approval_required_tool_is_ask(self):
+        manifest_with_approval = textwrap.dedent("""\
+            world_id: default
+            allowed_tools: [read_file, send_email]
+            capabilities:
+              read_file: {allowed: true}
+              send_email: {allowed: true, requires_approval: true}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """)
+        executor, tmp = _make_executor(manifest_with_approval)
+        gate = GeminiPolicyGate(executor)
+        mapper = IntentMapper(executor.registry)
+        tc = _tool_call("send_email")
+        intent = mapper.map(tc)
+        prov = Provenance.from_source("cli")
+        spec = gate.evaluate(intent, prov)
+        shutil.rmtree(tmp, ignore_errors=True)
+        self.assertIs(spec.decision, Decision.ASK)
+        self.assertEqual(spec.rule, "approval_required")
+
+
+class GeminiPolicyGateIntegrationTests(unittest.TestCase):
+    """Verify ExecutionSpec decisions are correctly reflected in the API response."""
+
+    def setUp(self):
+        import asyncio
+        import httpx
+        from api.main import create_app
+
+        executor, self._tmp = _make_executor()
+        self._app = create_app(self._tmp, executor=executor)
+
+        async def _post(payload):
+            transport = httpx.ASGITransport(app=self._app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as c:
+                return await c.post("/integrations/gemini/tools/execute", json=payload)
+
+        self._post = lambda p: asyncio.run(_post(p))
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_deny_from_policy_gate_short_circuits_executor(self):
+        # web-tainted send_email → gate says DENY, executor never called
+        resp = self._post({
+            "functionCall": {"name": "send_email", "args": {}},
+            "metadata": {"source_channel": "web"},
+        })
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()["functionResponse"]["response"]
+        self.assertEqual(body["decision"], "DENY")
+        self.assertEqual(body["rule"], "tainted_external_side_effect")
+
+    def test_absent_from_policy_gate_short_circuits_executor(self):
+        resp = self._post({
+            "functionCall": {"name": "dangerous_exec", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        })
+        body = resp.json()["functionResponse"]["response"]
+        self.assertEqual(body["decision"], "ABSENT")
+
+    def test_allow_from_policy_gate_reaches_executor(self):
+        resp = self._post({
+            "functionCall": {"name": "read_file", "args": {"path": "README.md"}},
+            "metadata": {"source_channel": "cli"},
+        })
+        body = resp.json()["functionResponse"]["response"]
+        self.assertEqual(body["decision"], "ALLOW")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gemini_proxy.py
+++ b/tests/test_gemini_proxy.py
@@ -147,5 +147,70 @@ class GeminiProxyEndpointTests(unittest.TestCase):
         self.assertIn("ALLOW", audit)
 
 
+class GeminiToolsListEndpointTests(unittest.TestCase):
+    """Tests for GET /integrations/gemini/tools/list (Issue #89)."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        # Only read_file and list_repo allowed — send_email is absent
+        (self.tmp / "world_manifest.yaml").write_text(textwrap.dedent("""\
+            world_id: default
+            allowed_tools: [read_file, list_repo]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: true}
+              send_email: {allowed: false}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text(_POLICY, encoding="utf-8")
+        logs_dir = self.tmp / "safe_mcp_proxy" / "logs"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "audit.jsonl").write_text("", encoding="utf-8")
+        self.app = create_app(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _get(self) -> httpx.Response:
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.get("/integrations/gemini/tools/list")
+        return asyncio.run(_run())
+
+    def test_returns_200(self):
+        self.assertEqual(self._get().status_code, 200)
+
+    def test_response_has_tools_key(self):
+        body = self._get().json()
+        self.assertIn("tools", body)
+        self.assertIsInstance(body["tools"], list)
+
+    def test_only_allowlisted_tools_are_returned(self):
+        names = {t["name"] for t in self._get().json()["tools"]}
+        self.assertIn("read_file", names)
+        self.assertIn("list_repo", names)
+
+    def test_absent_tool_is_not_in_list(self):
+        names = {t["name"] for t in self._get().json()["tools"]}
+        self.assertNotIn("send_email", names)
+        self.assertNotIn("dangerous_exec", names)
+
+    def test_each_tool_has_name_and_parameters(self):
+        for tool in self._get().json()["tools"]:
+            self.assertIn("name", tool)
+            self.assertIn("parameters", tool)
+
+    def test_parameters_is_json_schema_object(self):
+        for tool in self._get().json()["tools"]:
+            params = tool["parameters"]
+            self.assertEqual(params.get("type"), "object")
+            self.assertIn("properties", params)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gemini_proxy.py
+++ b/tests/test_gemini_proxy.py
@@ -1,0 +1,151 @@
+"""Tests for EPIC 8 Issue #88 — Gemini proxy passthrough endpoint."""
+import asyncio
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import httpx
+
+from api.main import create_app
+
+
+_MANIFEST = textwrap.dedent("""\
+    world_id: default
+    allowed_tools: [read_file, send_email]
+    capabilities:
+      read_file: {allowed: true}
+      send_email: {allowed: true}
+    taint_rules:
+      - tainted_external: deny
+    side_effects: {external: restricted}
+""")
+
+_POLICY = "simulation:\n  external_side_effects: true\n"
+
+
+class GeminiProxyEndpointTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "world_manifest.yaml").write_text(_MANIFEST, encoding="utf-8")
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text(_POLICY, encoding="utf-8")
+        logs_dir = self.tmp / "safe_mcp_proxy" / "logs"
+        logs_dir.mkdir(parents=True)
+        (logs_dir / "audit.jsonl").write_text("", encoding="utf-8")
+        self.app = create_app(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _post(self, payload: dict) -> httpx.Response:
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.post("/integrations/gemini/tools/execute", json=payload)
+        return asyncio.run(_run())
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_clean_read_file_is_allowed(self):
+        payload = {
+            "functionCall": {"name": "read_file", "args": {"path": "README.md"}},
+            "metadata": {"source_channel": "cli"},
+        }
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("functionResponse", body)
+        self.assertEqual(body["functionResponse"]["name"], "read_file")
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ALLOW")
+
+    def test_response_is_gemini_function_response_envelope(self):
+        payload = {"functionCall": {"name": "read_file", "args": {}}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertIn("functionResponse", body)
+        self.assertIn("name", body["functionResponse"])
+        self.assertIn("response", body["functionResponse"])
+
+    # ------------------------------------------------------------------
+    # Policy enforcement via executor
+    # ------------------------------------------------------------------
+
+    def test_tainted_send_email_is_denied(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {"to": "x@example.com", "body": "hi"}},
+            "metadata": {"source_channel": "web"},
+        }
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "DENY")
+        self.assertEqual(
+            body["functionResponse"]["response"]["rule"],
+            "tainted_external_side_effect",
+        )
+
+    def test_unknown_tool_returns_absent(self):
+        payload = {"functionCall": {"name": "exfiltrate_everything", "args": {}}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ABSENT")
+
+    def test_source_channel_defaults_to_web_when_omitted(self):
+        # send_email without metadata → defaults to web (tainted) → DENY
+        payload = {
+            "functionCall": {"name": "send_email", "args": {"to": "x@example.com", "body": "hi"}},
+        }
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.json()["functionResponse"]["response"]["decision"], "DENY"
+        )
+
+    # ------------------------------------------------------------------
+    # Malformed requests → 422
+    # ------------------------------------------------------------------
+
+    def test_missing_function_call_returns_422(self):
+        resp = self._post({"something": "else"})
+        self.assertEqual(resp.status_code, 422)
+
+    def test_missing_tool_name_returns_422(self):
+        resp = self._post({"functionCall": {"args": {"path": "README.md"}}})
+        self.assertEqual(resp.status_code, 422)
+
+    def test_non_dict_body_returns_422(self):
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.post(
+                    "/integrations/gemini/tools/execute",
+                    content=b'"just a string"',
+                    headers={"content-type": "application/json"},
+                )
+        resp = asyncio.run(_run())
+        self.assertEqual(resp.status_code, 422)
+
+    # ------------------------------------------------------------------
+    # Audit logging
+    # ------------------------------------------------------------------
+
+    def test_request_is_logged_to_audit_file(self):
+        payload = {
+            "functionCall": {"name": "read_file", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        }
+        self._post(payload)
+        audit = (self.tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl").read_text(encoding="utf-8")
+        self.assertIn("read_file", audit)
+        self.assertIn("ALLOW", audit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intent_ir.py
+++ b/tests/test_intent_ir.py
@@ -1,0 +1,194 @@
+"""Tests for EPIC 8 Issue #90 — Intent IR Mapping (ToolCall → IntentIR)."""
+import unittest
+
+from safe_mcp_proxy.integrations.gemini_adapter import GeminiAdapter
+from safe_mcp_proxy.integrations.intent_ir import IntentIR, IntentIRError, IntentMapper
+from safe_mcp_proxy.registry import ToolRegistry
+
+
+def _make_registry(allowlist=("read_file",)) -> ToolRegistry:
+    return ToolRegistry.with_mock_tools(allowlist=allowlist)
+
+
+class IntentIRDataclassTests(unittest.TestCase):
+    def test_is_frozen(self):
+        ir = IntentIR(
+            action="read_file",
+            parameters={"path": "README.md"},
+            required_capabilities=["read_file"],
+            side_effect_type="read",
+            descriptor_hash="abc123",
+        )
+        with self.assertRaises((AttributeError, TypeError)):
+            ir.action = "other"  # type: ignore[misc]
+
+    def test_fields_are_accessible(self):
+        ir = IntentIR(
+            action="send_email",
+            parameters={"to": "a@b.com"},
+            required_capabilities=["send_email"],
+            side_effect_type="external",
+            descriptor_hash="deadbeef",
+        )
+        self.assertEqual(ir.action, "send_email")
+        self.assertEqual(ir.parameters, {"to": "a@b.com"})
+        self.assertEqual(ir.required_capabilities, ["send_email"])
+        self.assertEqual(ir.side_effect_type, "external")
+        self.assertEqual(ir.descriptor_hash, "deadbeef")
+
+
+class IntentIRErrorTests(unittest.TestCase):
+    def test_carries_action_name(self):
+        err = IntentIRError("exfiltrate_everything")
+        self.assertEqual(err.action, "exfiltrate_everything")
+
+    def test_is_key_error_subclass(self):
+        self.assertIsInstance(IntentIRError("x"), KeyError)
+
+    def test_message_contains_action(self):
+        err = IntentIRError("bad_tool")
+        self.assertIn("bad_tool", str(err))
+
+
+class IntentMapperTests(unittest.TestCase):
+    def setUp(self):
+        # allowlist only read_file; send_email is registered but not exposed
+        self._registry = _make_registry(allowlist=("read_file",))
+        self._mapper = IntentMapper(self._registry)
+
+    def _make_tool_call(self, name: str, args: dict | None = None):
+        return GeminiAdapter.parse({
+            "functionCall": {"name": name, "args": args or {}},
+        })
+
+    # ------------------------------------------------------------------
+    # Happy-path mapping
+    # ------------------------------------------------------------------
+
+    def test_maps_allowlisted_tool(self):
+        tool_call = self._make_tool_call("read_file", {"path": "README.md"})
+        ir = self._mapper.map(tool_call)
+        self.assertIsInstance(ir, IntentIR)
+        self.assertEqual(ir.action, "read_file")
+        self.assertEqual(ir.parameters, {"path": "README.md"})
+
+    def test_required_capabilities_contains_tool_capability(self):
+        tool_call = self._make_tool_call("read_file")
+        ir = self._mapper.map(tool_call)
+        self.assertIn("read_file", ir.required_capabilities)
+
+    def test_side_effect_type_is_populated(self):
+        tool_call = self._make_tool_call("read_file")
+        ir = self._mapper.map(tool_call)
+        self.assertIsNotNone(ir.side_effect_type)
+        self.assertIsInstance(ir.side_effect_type, str)
+
+    def test_descriptor_hash_is_populated(self):
+        tool_call = self._make_tool_call("read_file")
+        ir = self._mapper.map(tool_call)
+        self.assertIsNotNone(ir.descriptor_hash)
+        self.assertGreater(len(ir.descriptor_hash), 0)
+
+    def test_empty_args_become_empty_parameters(self):
+        tool_call = self._make_tool_call("read_file")
+        ir = self._mapper.map(tool_call)
+        self.assertEqual(ir.parameters, {})
+
+    # ------------------------------------------------------------------
+    # Ontology membership: known but not allowlisted still maps
+    # ------------------------------------------------------------------
+
+    def test_maps_known_but_non_allowlisted_tool(self):
+        # send_email is in the registry's full catalog even though not allowlisted
+        tool_call = self._make_tool_call("send_email", {"to": "x@example.com"})
+        ir = self._mapper.map(tool_call)
+        self.assertEqual(ir.action, "send_email")
+        self.assertEqual(ir.side_effect_type, "external")
+
+    # ------------------------------------------------------------------
+    # Unknown tool → IntentIRError
+    # ------------------------------------------------------------------
+
+    def test_completely_unknown_tool_raises_intent_ir_error(self):
+        tool_call = self._make_tool_call("exfiltrate_everything")
+        with self.assertRaises(IntentIRError) as ctx:
+            self._mapper.map(tool_call)
+        self.assertEqual(ctx.exception.action, "exfiltrate_everything")
+
+    def test_empty_name_raises_intent_ir_error(self):
+        # GeminiAdapter rejects empty name, but we test mapper directly
+        from safe_mcp_proxy.integrations.gemini_adapter import ToolCall
+        tool_call = ToolCall(
+            tool_name="ghost_tool",
+            arguments={},
+            session_id=None,
+            agent_id=None,
+            metadata={},
+            raw_request={},
+        )
+        with self.assertRaises(IntentIRError):
+            self._mapper.map(tool_call)
+
+
+class IntentMapperIntegrationTests(unittest.TestCase):
+    """Verify IntentMapper is correctly wired into GeminiProxy.execute()."""
+
+    def setUp(self):
+        import shutil
+        import tempfile
+        import textwrap
+        from pathlib import Path
+        from api.main import create_app
+
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "world_manifest.yaml").write_text(textwrap.dedent("""\
+            world_id: default
+            allowed_tools: [read_file]
+            capabilities:
+              read_file: {allowed: true}
+            taint_rules:
+              - tainted_external: deny
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+        config_dir = self.tmp / "safe_mcp_proxy" / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "policy.yaml").write_text(
+            "simulation:\n  external_side_effects: true\n", encoding="utf-8"
+        )
+        (self.tmp / "safe_mcp_proxy" / "logs").mkdir(parents=True)
+        (self.tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl").write_text("", encoding="utf-8")
+        self.app = create_app(self.tmp)
+        self._shutil = shutil
+
+    def tearDown(self):
+        self._shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _post(self, payload: dict):
+        import asyncio
+        import httpx
+
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.post("/integrations/gemini/tools/execute", json=payload)
+        return asyncio.run(_run())
+
+    def test_ontologically_absent_tool_returns_action_not_in_ontology(self):
+        payload = {"functionCall": {"name": "exfiltrate_everything", "args": {}}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ABSENT")
+        self.assertEqual(body["functionResponse"]["response"]["rule"], "action_not_in_ontology")
+
+    def test_allowlist_absent_tool_returns_executor_absent(self):
+        # send_email is in the catalog but not in the allowlist → executor ABSENT
+        payload = {"functionCall": {"name": "send_email", "args": {}}}
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ABSENT")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements Phase 1 of the Gemini integration: a thin HTTP surface that
routes Gemini functionCall requests through the existing executor pipeline.

- GeminiProxy class wraps executor; source_channel from request metadata
  defaults to "web" (tainted) when absent
- POST /integrations/gemini/tools/execute in api/main.py
- 9 tests covering allow, deny, absent, 422, and audit logging

Closes #88

https://claude.ai/code/session_01EkzxudDVwghAyUdGWPYxAU