### PR TITLE
feat(gemini): simulate mode for safe replanning fallback (EPIC 8 / Issue #98)

### DIFF
--- a/safe_mcp_proxy/executor.py
+++ b/safe_mcp_proxy/executor.py
@@ -414,6 +414,24 @@ class Executor:
             source_channel=source_channel,
         )
 
+    def record_simulation(
+        self,
+        tool_name: str,
+        rule: str,
+        source_channel: str,
+        taint: bool = False,
+    ) -> None:
+        """Log a SIMULATE decision to the audit trail without executing anything."""
+        self._audit(
+            tool=tool_name,
+            decision="SIMULATE",
+            rule=rule,
+            taint=taint,
+            descriptor_hash="",
+            source_channel=source_channel,
+            simulated=True,
+        )
+
     def _audit(
         self,
         tool: str,

--- a/safe_mcp_proxy/integrations/execution_spec.py
+++ b/safe_mcp_proxy/integrations/execution_spec.py
@@ -15,7 +15,7 @@ class ExecutionSpec:
     Sits between IntentIR mapping and execution routing (Issue #93).
 
     Fields:
-        decision  — ALLOW / DENY / ABSENT / ASK
+        decision  — ALLOW / DENY / ABSENT / ASK / SIMULATE
         rule      — the specific rule that produced the decision
         intent    — the resolved IntentIR this spec was built from
         provenance — taint / source / mode context that influenced the decision

--- a/safe_mcp_proxy/integrations/gemini_policy_gate.py
+++ b/safe_mcp_proxy/integrations/gemini_policy_gate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from safe_mcp_proxy.decision import Decision
 from safe_mcp_proxy.descriptor import descriptor_hash_valid
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.integrations.execution_spec import ExecutionSpec
@@ -22,6 +23,7 @@ class GeminiPolicyGate:
     def __init__(self, executor: Executor) -> None:
         self._policy = executor.policy_engine
         self._registry = executor.registry
+        self._simulate_external: bool = executor.simulate_external
 
     def evaluate(self, intent: IntentIR, provenance: Provenance) -> ExecutionSpec:
         """Run policy evaluation for intent and return a typed ExecutionSpec.
@@ -48,6 +50,18 @@ class GeminiPolicyGate:
             side_effect_type=intent.side_effect_type,
             descriptor_hash_valid=hash_ok,
         )
+
+        if (
+            policy_result.decision == Decision.ALLOW
+            and self._simulate_external
+            and intent.side_effect_type == "external"
+        ):
+            return ExecutionSpec(
+                decision=Decision.SIMULATE,
+                rule="simulate_external_action",
+                intent=intent,
+                provenance=provenance,
+            )
 
         return ExecutionSpec(
             decision=policy_result.decision,

--- a/safe_mcp_proxy/integrations/gemini_proxy.py
+++ b/safe_mcp_proxy/integrations/gemini_proxy.py
@@ -9,6 +9,7 @@ from safe_mcp_proxy.integrations.gemini_policy_gate import GeminiPolicyGate
 from safe_mcp_proxy.integrations.gemini_trace import GeminiTraceLogger
 from safe_mcp_proxy.integrations.intent_ir import IntentIRError, IntentMapper
 from safe_mcp_proxy.provenance import Provenance
+from safe_mcp_proxy.simulate import simulate_external_action
 
 _ABSENCE_MESSAGE = "Action does not exist in this world"
 
@@ -23,6 +24,7 @@ class GeminiProxy:
         executor.execute()          →  result + audit log  (ALLOW / ASK)
         executor.execute()          →  ABSENT result + audit log  (allowlist miss)
         short-circuit               →  DENY response (logged via record_denial)
+        short-circuit               →  SIMULATE response (logged via record_simulation)
     """
 
     def __init__(
@@ -129,6 +131,32 @@ class GeminiProxy:
                 "message": f"Action blocked by policy: {spec.rule}",
                 "result": None,
             }
+            return GeminiAdapter.format_response(tool_call.tool_name, result)
+
+        if spec.decision == Decision.SIMULATE:
+            self._executor.record_simulation(
+                tool_name=intent.action,
+                rule=spec.rule,
+                source_channel=provenance.source_channel,
+                taint=provenance.tainted,
+            )
+            result = {
+                "decision": Decision.SIMULATE.value,
+                "rule": spec.rule,
+                "simulated": True,
+                "result": simulate_external_action(),
+            }
+            if self._trace:
+                self._trace.record(
+                    stage="execution",
+                    tool=intent.action,
+                    taint=provenance.tainted,
+                    source_channel=source,
+                    world_id=world_id,
+                    decision=Decision.SIMULATE.value,
+                    rule=spec.rule,
+                    simulated=True,
+                )
             return GeminiAdapter.format_response(tool_call.tool_name, result)
 
         # ABSENT (allowlist miss), ALLOW, ASK: delegate to executor.

--- a/tests/test_gemini_simulate.py
+++ b/tests/test_gemini_simulate.py
@@ -1,0 +1,208 @@
+"""Tests for EPIC 8 Issue #98 — Gemini Simulate Mode (Safe Replanning Fallback)."""
+import asyncio
+import json
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+import httpx
+
+from api.main import create_app
+
+
+_MANIFEST_WITH_SIMULATE = textwrap.dedent("""\
+    world_id: default
+    allowed_tools: [read_file, send_email]
+    capabilities:
+      read_file: {allowed: true}
+      send_email: {allowed: true}
+    taint_rules:
+      - tainted_external: deny
+    side_effects: {external: restricted}
+""")
+
+_MANIFEST_NO_SIMULATE = textwrap.dedent("""\
+    world_id: default
+    allowed_tools: [read_file, send_email]
+    capabilities:
+      read_file: {allowed: true}
+      send_email: {allowed: true}
+    taint_rules:
+      - tainted_external: deny
+    side_effects: {external: restricted}
+""")
+
+_POLICY_SIMULATE_ON = "simulation:\n  external_side_effects: true\n"
+_POLICY_SIMULATE_OFF = "simulation:\n  external_side_effects: false\n"
+
+
+def _build_app(tmp: Path, policy_text: str) -> object:
+    (tmp / "world_manifest.yaml").write_text(_MANIFEST_WITH_SIMULATE, encoding="utf-8")
+    config_dir = tmp / "safe_mcp_proxy" / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "policy.yaml").write_text(policy_text, encoding="utf-8")
+    logs_dir = tmp / "safe_mcp_proxy" / "logs"
+    logs_dir.mkdir(parents=True)
+    (logs_dir / "audit.jsonl").write_text("", encoding="utf-8")
+    return create_app(tmp)
+
+
+def _post(app, payload: dict) -> httpx.Response:
+    async def _run():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post("/integrations/gemini/tools/execute", json=payload)
+    return asyncio.run(_run())
+
+
+class TestGeminiSimulateDecision(unittest.TestCase):
+    """Simulate path is taken when simulate_external=True + clean source + external tool."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.app = _build_app(self.tmp, _POLICY_SIMULATE_ON)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _send_email_cli(self) -> dict:
+        payload = {
+            "functionCall": {"name": "send_email", "args": {"to": "a@example.com", "body": "hi"}},
+            "metadata": {"source_channel": "cli"},
+        }
+        return _post(self.app, payload).json()
+
+    def test_clean_external_tool_returns_simulate_decision(self):
+        body = self._send_email_cli()
+        self.assertEqual(
+            body["functionResponse"]["response"]["decision"], "SIMULATE"
+        )
+
+    def test_simulate_response_contains_simulated_true(self):
+        body = self._send_email_cli()
+        self.assertTrue(body["functionResponse"]["response"]["simulated"])
+
+    def test_simulate_result_matches_simulate_external_action_output(self):
+        from safe_mcp_proxy.simulate import simulate_external_action
+        body = self._send_email_cli()
+        self.assertEqual(
+            body["functionResponse"]["response"]["result"],
+            simulate_external_action(),
+        )
+
+    def test_simulate_response_wrapped_in_gemini_envelope(self):
+        body = self._send_email_cli()
+        self.assertIn("functionResponse", body)
+        self.assertEqual(body["functionResponse"]["name"], "send_email")
+        self.assertIn("response", body["functionResponse"])
+
+    def test_simulate_rule_is_simulate_external_action(self):
+        body = self._send_email_cli()
+        self.assertEqual(
+            body["functionResponse"]["response"]["rule"], "simulate_external_action"
+        )
+
+    def test_simulate_returns_200(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {"to": "a@example.com", "body": "hi"}},
+            "metadata": {"source_channel": "cli"},
+        }
+        resp = _post(self.app, payload)
+        self.assertEqual(resp.status_code, 200)
+
+
+class TestGeminiSimulateAuditLog(unittest.TestCase):
+    """SIMULATE decision is recorded in the audit trail with simulated=true."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.app = _build_app(self.tmp, _POLICY_SIMULATE_ON)
+        self.audit_path = self.tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_simulate_logged_with_simulate_decision(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        }
+        _post(self.app, payload)
+        entries = [json.loads(l) for l in self.audit_path.read_text().splitlines() if l]
+        simulate_entries = [e for e in entries if e.get("decision") == "SIMULATE"]
+        self.assertEqual(len(simulate_entries), 1)
+
+    def test_simulate_audit_entry_has_simulated_true(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        }
+        _post(self.app, payload)
+        entries = [json.loads(l) for l in self.audit_path.read_text().splitlines() if l]
+        simulate_entry = next(e for e in entries if e.get("decision") == "SIMULATE")
+        self.assertTrue(simulate_entry.get("simulated"))
+
+    def test_simulate_audit_entry_has_correct_tool_and_rule(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {}},
+            "metadata": {"source_channel": "cli"},
+        }
+        _post(self.app, payload)
+        entries = [json.loads(l) for l in self.audit_path.read_text().splitlines() if l]
+        simulate_entry = next(e for e in entries if e.get("decision") == "SIMULATE")
+        self.assertEqual(simulate_entry["tool"], "send_email")
+        self.assertEqual(simulate_entry["rule"], "simulate_external_action")
+
+
+class TestGeminiSimulatePrecedence(unittest.TestCase):
+    """Other policy rules take precedence over simulate mode."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.app = _build_app(self.tmp, _POLICY_SIMULATE_ON)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_tainted_external_is_still_deny_not_simulate(self):
+        payload = {
+            "functionCall": {"name": "send_email", "args": {"to": "x@example.com", "body": "hi"}},
+            "metadata": {"source_channel": "web"},
+        }
+        body = _post(self.app, payload).json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "DENY")
+        self.assertEqual(
+            body["functionResponse"]["response"]["rule"], "tainted_external_side_effect"
+        )
+
+    def test_non_external_tool_with_simulate_mode_is_allow(self):
+        payload = {
+            "functionCall": {"name": "read_file", "args": {"path": "README.md"}},
+            "metadata": {"source_channel": "cli"},
+        }
+        body = _post(self.app, payload).json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ALLOW")
+
+    def test_simulate_mode_off_external_tool_is_allow(self):
+        tmp2 = Path(tempfile.mkdtemp())
+        try:
+            app2 = _build_app(tmp2, _POLICY_SIMULATE_OFF)
+            payload = {
+                "functionCall": {"name": "send_email", "args": {"to": "x@example.com", "body": "hi"}},
+                "metadata": {"source_channel": "cli"},
+            }
+            body = _post(app2, payload).json()
+            self.assertEqual(body["functionResponse"]["response"]["decision"], "ALLOW")
+        finally:
+            shutil.rmtree(tmp2, ignore_errors=True)
+
+    def test_unknown_tool_is_absent_not_simulate(self):
+        payload = {"functionCall": {"name": "exfiltrate_all", "args": {}}}
+        body = _post(self.app, payload).json()
+        self.assertEqual(body["functionResponse"]["response"]["decision"], "ABSENT")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a SIMULATE decision path to the Gemini integration so external
side-effect tools return a deterministic synthetic response instead of
executing, enabling the agent to replan safely without triggering real
actions.

- GeminiPolicyGate promotes ALLOW → SIMULATE when simulate_external is
  enabled and the tool has an external side effect (tainted paths still
  resolve to DENY via rule 4, taking precedence)
- GeminiProxy handles the SIMULATE branch explicitly: calls
  simulate_external_action(), logs to audit and trace, returns response
  with simulated=true — never reaches executor.execute()
- Executor gains record_simulation() parallel to record_denial() /
  record_absence(); audit entries carry simulated=true
- 13 new tests covering decision, audit log, Gemini envelope, and
  precedence rules (taint→DENY, non-external→ALLOW, flag-off→ALLOW)

https://claude.ai/code/session_01TTBKrSsmsYgg8NygCWWmN3