### PR TITLE
feat: dynamic world switching via WorldController

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,7 @@ from safe_mcp_proxy.integrations.gemini_proxy import GeminiProxy
 from safe_mcp_proxy.main import build_executor
 from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.trace_store import TraceStore
+from safe_mcp_proxy.world_controller import WorldController, WorldNotFoundError
 
 
 class CompareRequest(BaseModel):
@@ -334,6 +335,8 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     app = FastAPI(title="safe-mcp-proxy API")
     app.state.trace_store = _build_trace_store(resolved_base_dir)
     app.state.executor = executor or build_executor(resolved_base_dir)
+    # Expose the WorldController directly on app.state so switch endpoints can use it.
+    app.state.world_controller = getattr(app.state.executor, "world_controller", None)
     app.state.gemini_proxy = GeminiProxy(app.state.executor)
 
     app.add_middleware(
@@ -490,15 +493,56 @@ def create_app(base_dir: Optional[Path] = None, executor: Optional[Executor] = N
     @app.get("/worlds/current")
     async def worlds_current() -> dict:
         """Return active world_id and its exposed tool surface."""
-        tools = [
-            {
-                "name": t.name,
-                "capability": t.capability,
-                "side_effect_type": t.side_effect_type,
-            }
-            for t in app.state.executor.registry.list_exposed()
-        ]
-        return {"world_id": app.state.executor.world_id, "tools": tools}
+        wc: Optional[WorldController] = app.state.world_controller
+        if wc is not None:
+            tool_list = wc.list_tools()
+            wid = wc.current_id()
+        else:
+            tool_list = [
+                {"name": t.name, "capability": t.capability, "side_effect_type": t.side_effect_type}
+                for t in app.state.executor.registry.list_exposed()
+            ]
+            wid = app.state.executor.world_id
+        return {"world_id": wid, "tools": tool_list}
+
+    # ------------------------------------------------------------------
+    # Dynamic world switching (EPIC dynamic-world-switching)
+    # ------------------------------------------------------------------
+
+    def _write_world_switch_event(diff: dict) -> None:
+        """Append a WORLD_SWITCH event to audit.jsonl."""
+        import json as _json
+        from datetime import datetime, timezone
+        audit_path = resolved_base_dir / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "event": "WORLD_SWITCH",
+            "diff": diff,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        with audit_path.open("a", encoding="utf-8") as fh:
+            fh.write(_json.dumps(event, sort_keys=True) + "\n")
+
+    @app.post("/world/switch")
+    async def world_switch(world_id: str = Query(...), reason: str = Query(default="")) -> dict:
+        """Switch the active world and return a diff of appeared/vanished tools."""
+        wc: Optional[WorldController] = app.state.world_controller
+        if wc is None:
+            raise HTTPException(status_code=501, detail="WorldController not available")
+        try:
+            diff = wc.switch(world_id, reason=reason)
+        except WorldNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        _write_world_switch_event(diff)
+        return diff
+
+    @app.get("/world/current")
+    async def world_current() -> dict:
+        """Return the active world_id and the full switch history."""
+        wc: Optional[WorldController] = app.state.world_controller
+        if wc is None:
+            return {"world_id": app.state.executor.world_id, "history": []}
+        return {"world_id": wc.current_id(), "history": wc.history}
 
     # ------------------------------------------------------------------
     # Approval endpoints (DS7.1)

--- a/safe_mcp_proxy/compiler.py
+++ b/safe_mcp_proxy/compiler.py
@@ -1,9 +1,34 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import yaml
 
 from safe_mcp_proxy.capability_dsl import parse_capability_definitions
+
+
+def resolve_manifest_path(base_dir: Path, world_id: Optional[str]) -> Path:
+    """Resolve the filesystem path for a world manifest.
+
+    None / empty string → root world_manifest.yaml (default world).
+    Named world_id → searched in safe_mcp_proxy/config/worlds/ then worlds/.
+    Raises FileNotFoundError when no matching file is found.
+    """
+    if not world_id:
+        return base_dir / "world_manifest.yaml"
+
+    candidates = [
+        base_dir / "safe_mcp_proxy" / "config" / "worlds" / f"{world_id}.yaml",
+        base_dir / "worlds" / f"{world_id}.yaml",
+    ]
+    for path in candidates:
+        if path.exists():
+            return path
+
+    searched = ", ".join(str(p) for p in candidates)
+    raise FileNotFoundError(
+        f"World manifest not found for world_id={world_id!r}. Searched: {searched}"
+    )
 
 
 @dataclass

--- a/safe_mcp_proxy/executor.py
+++ b/safe_mcp_proxy/executor.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from safe_mcp_proxy.approval_store import ApprovalStore
 from safe_mcp_proxy.capability_projection import CapabilityProjectionEngine, ProjectionContext, ProjectionResult
@@ -13,6 +13,9 @@ from safe_mcp_proxy.policy_engine import PolicyEngine
 from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.registry import Tool, ToolRegistry
 from safe_mcp_proxy.simulate import simulate_external_action
+
+if TYPE_CHECKING:
+    from safe_mcp_proxy.world_controller import WorldController
 
 ABSENT_MESSAGE = "Action does not exist in this world"
 
@@ -58,6 +61,8 @@ class Executor:
         skill_capabilities: Optional[Dict[str, SkillCapabilityConfig]] = None,
         world_id: str = "",
         policy_version: str = "",
+        world_controller: Optional["WorldController"] = None,
+        base_dir: Optional[Path] = None,
     ):
         self.registry = registry
         self.policy_engine = policy_engine
@@ -66,16 +71,66 @@ class Executor:
         self.approval_store = approval_store or ApprovalStore()
         self.projection_engine = projection_engine
         self.skill_capabilities: Dict[str, SkillCapabilityConfig] = skill_capabilities or {}
-        self.world_id = world_id
+        self._stored_world_id = world_id
         self.policy_version = policy_version
+        self.world_controller = world_controller
+        self._base_dir = base_dir
+
+    # ------------------------------------------------------------------
+    # world_id — reads from WorldController when present
+    # ------------------------------------------------------------------
+
+    @property
+    def world_id(self) -> str:
+        if self.world_controller is not None:
+            return self.world_controller.current_id()
+        return self._stored_world_id
+
+    # ------------------------------------------------------------------
+    # Dynamic world resolution
+    # ------------------------------------------------------------------
+
+    def _build_policy_for_world(self, world: Dict[str, Any]) -> "PolicyEngine":
+        """Build a policy engine from a compiled world dict."""
+        approval_required = world.get("approval_required", [])
+        engine_name = world.get("policy_engine", "python")
+        if engine_name == "opa" and self._base_dir:
+            from safe_mcp_proxy.opa_engine import OPAPolicyEngine
+            policy_path = str(self._base_dir / "safe_mcp_proxy" / "policies" / "proxy.rego")
+            return OPAPolicyEngine(  # type: ignore[return-value]
+                policy_path=policy_path,
+                allowlist=world["allowlist"],
+                capability_map=world["capability_map"],
+                approval_required=approval_required,
+            )
+        return PolicyEngine(
+            allowlist=world.get("allowlist", []),
+            capability_map=world.get("capability_map", {}),
+            approval_required=approval_required,
+        )
+
+    def _resolve_components(self) -> Tuple[ToolRegistry, "PolicyEngine", str]:
+        """Return (registry, policy_engine, world_id) for the current call.
+
+        When WorldController is present we keep using the stored registry so
+        that in-memory mutations (e.g. descriptor-drift tests that corrupt a
+        tool schema) are still detected.  Only the policy engine is rebuilt
+        from the current world on every call so that world switches take effect
+        immediately without rebuilding the full tool catalog.
+        """
+        if self.world_controller is not None:
+            world = self.world_controller.world
+            wid = self.world_controller.current_id()
+            policy_engine = self._build_policy_for_world(world)
+            return self.registry, policy_engine, wid  # type: ignore[return-value]
+        return self.registry, self.policy_engine, self._stored_world_id
+
+    # ------------------------------------------------------------------
+    # list_tools (projection-based, for skill capabilities)
+    # ------------------------------------------------------------------
 
     def list_tools(self, context: ProjectionContext) -> ProjectionResult:
-        """Return projected skill capabilities for the given execution context.
-
-        Only capabilities explicitly declared in the world manifest and passing
-        all projection filters are included in the visible list.
-        Every call is logged to the audit trail.
-        """
+        """Return projected skill capabilities for the given execution context."""
         if not self.projection_engine or not self.skill_capabilities:
             result = ProjectionResult(visible=[], hidden=[])
         else:
@@ -87,7 +142,6 @@ class Executor:
             taint=False,
             descriptor_hash="",
             source_channel="",
-            world_id=self.world_id,
             policy_version=self.policy_version,
             identity=context.identity,
             workflow_id=context.workflow_id,
@@ -97,6 +151,10 @@ class Executor:
         )
         return result
 
+    # ------------------------------------------------------------------
+    # Skill execution
+    # ------------------------------------------------------------------
+
     def execute_skill(
         self,
         tool_name: str,
@@ -104,20 +162,9 @@ class Executor:
         context: ProjectionContext,
         provenance: Provenance,
     ) -> Dict[str, Any]:
-        """Execution guard for skill-backed capabilities.
-
-        Check order (first failure is terminal):
-          1. capability_not_defined   — tool absent from skill_capabilities
-          2. capability_not_allowed   — manifest declares allowed: false
-          3. capability_not_visible   — mode/workflow side-effect filter
-          4. provenance_violation     — tainted source + provenance_required
-          5. approval_required        — requires_approval and not yet approved
-          6. constraint_violation_*   — payload fails declared constraints
-          7. ALLOW
-        """
+        """Execution guard for skill-backed capabilities."""
         source_provenance = [provenance.source_channel] if provenance.source_channel else []
         extra: Dict[str, Any] = {
-            "world_id": self.world_id,
             "policy_version": self.policy_version,
             "identity": context.identity,
             "workflow_id": context.workflow_id,
@@ -196,18 +243,29 @@ class Executor:
         msg = f"Denied: {reason}" + (f" ({detail})" if detail else "")
         return {"decision": "DENY", "rule": reason, "result": {"error": msg}}
 
-    def _tool_context(self, tool_name: str) -> Tuple[Optional[Tool], str, str, bool]:
-        tool = self.registry.get_tool(tool_name)
+    # ------------------------------------------------------------------
+    # Core execute
+    # ------------------------------------------------------------------
+
+    def _tool_context(
+        self,
+        tool_name: str,
+        registry: Optional[ToolRegistry] = None,
+    ) -> Tuple[Optional[Tool], str, str, bool]:
+        reg = registry if registry is not None else self.registry
+        tool = reg.get_tool(tool_name)
         capability = tool.capability if tool else tool_name
         side_effect_type = tool.side_effect_type if tool else "unknown"
         hash_ok = descriptor_hash_valid(tool.schema, tool.descriptor_hash) if tool else True
         return tool, capability, side_effect_type, hash_ok
 
     def execute(self, tool_name: str, payload: Dict[str, Any], provenance: Provenance) -> Dict[str, Any]:
-        tool, capability, side_effect_type, hash_ok = self._tool_context(tool_name)
+        _registry, _policy_engine, _world_id = self._resolve_components()
+
+        tool, capability, side_effect_type, hash_ok = self._tool_context(tool_name, _registry)
         descriptor_hash = compute_descriptor_hash(tool.schema) if tool else ""
 
-        policy = self.policy_engine.decide(
+        policy = _policy_engine.decide(
             tool_name=tool_name,
             capability=capability,
             taint=provenance.tainted,
@@ -216,10 +274,16 @@ class Executor:
         )
 
         if policy.decision == Decision.ALLOW:
-            if self.simulate_external and tool and tool.side_effect_type == "external":
+            # `tool` may be None when a world switch added a tool that wasn't in
+            # the stored registry's original allowlist.  Fall back to the full
+            # catalog so we can still run it (the policy already cleared it).
+            exec_tool = tool or _registry.get_any_tool(tool_name)
+            if self.simulate_external and exec_tool and exec_tool.side_effect_type == "external":
                 response = simulate_external_action()
+            elif exec_tool:
+                response = exec_tool.handler(payload)
             else:
-                response = self.registry.execute_tool(tool_name, payload)
+                response = _registry.execute_tool(tool_name, payload)  # raises if still missing
             self._audit(
                 tool=tool_name,
                 decision=policy.decision.value,
@@ -227,6 +291,7 @@ class Executor:
                 taint=provenance.tainted,
                 descriptor_hash=descriptor_hash,
                 source_channel=provenance.source_channel,
+                world_id=_world_id,
             )
             return {"decision": policy.decision.value, "rule": policy.rule_hit, "result": response}
 
@@ -239,12 +304,12 @@ class Executor:
                 taint=provenance.tainted,
                 descriptor_hash=descriptor_hash,
                 source_channel=provenance.source_channel,
+                world_id=_world_id,
             )
             return {"decision": policy.decision.value, "rule": policy.rule_hit, "result": response}
 
         elif policy.decision == Decision.ASK:
             if provenance.execution_mode == ExecutionMode.BACKGROUND:
-                # Background mode cannot prompt for approval — fall back to DENY
                 effective_rule = "ask_unavailable_in_background"
                 response = {"error": "Denied by policy", "reason": effective_rule}
                 self._audit(
@@ -254,10 +319,10 @@ class Executor:
                     taint=provenance.tainted,
                     descriptor_hash=descriptor_hash,
                     source_channel=provenance.source_channel,
+                    world_id=_world_id,
                 )
                 return {"decision": Decision.DENY.value, "rule": effective_rule, "result": response}
             else:
-                # INTERACTIVE mode — create token and surface for approval
                 token = self.approval_store.create(
                     tool_name=tool_name,
                     payload=payload,
@@ -272,6 +337,7 @@ class Executor:
                     taint=provenance.tainted,
                     descriptor_hash=descriptor_hash,
                     source_channel=provenance.source_channel,
+                    world_id=_world_id,
                 )
                 return {
                     "decision": Decision.ASK.value,
@@ -290,6 +356,7 @@ class Executor:
                 taint=provenance.tainted,
                 descriptor_hash=descriptor_hash,
                 source_channel=provenance.source_channel,
+                world_id=_world_id,
             )
             return {"decision": policy.decision.value, "rule": policy.rule_hit, "result": response}
 
@@ -301,7 +368,9 @@ class Executor:
         if entry.status != "approved":
             return {"error": f"Token is {entry.status}, not approved", "approval_token": token}
 
-        tool = self.registry.get_tool(entry.tool_name)
+        _registry, _, _world_id = self._resolve_components()
+
+        tool = _registry.get_tool(entry.tool_name)
         descriptor_hash = compute_descriptor_hash(tool.schema) if tool else ""
 
         if tool is None:
@@ -311,7 +380,7 @@ class Executor:
             response = simulate_external_action()
             decision_val, rule_val = Decision.ALLOW.value, "approved"
         else:
-            response = self.registry.execute_tool(entry.tool_name, entry.payload)
+            response = _registry.execute_tool(entry.tool_name, entry.payload)
             decision_val, rule_val = Decision.ALLOW.value, "approved"
 
         self.approval_store.mark_executed(token)
@@ -322,6 +391,7 @@ class Executor:
             taint=entry.tainted,
             descriptor_hash=descriptor_hash,
             source_channel=entry.source_channel,
+            world_id=_world_id,
         )
         return {
             "decision": decision_val,
@@ -339,7 +409,8 @@ class Executor:
             return {"error": f"Token is already {entry.status}", "approval_token": token}
 
         self.approval_store.reject(token)
-        tool = self.registry.get_tool(entry.tool_name)
+        _registry, _, _world_id = self._resolve_components()
+        tool = _registry.get_tool(entry.tool_name)
         descriptor_hash = compute_descriptor_hash(tool.schema) if tool else ""
 
         self._audit(
@@ -349,6 +420,7 @@ class Executor:
             taint=entry.tainted,
             descriptor_hash=descriptor_hash,
             source_channel=entry.source_channel,
+            world_id=_world_id,
         )
         return {
             "decision": Decision.DENY.value,
@@ -357,13 +429,34 @@ class Executor:
             "result": {"error": "Denied by policy", "reason": "approval_rejected"},
         }
 
+    # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
     def replay(self, audit_entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Re-evaluate policy for a recorded audit entry.
+
+        Entries written before world_id was recorded (old seeds / live logs)
+        will have no world_id key; in that case we fall back to the stored
+        registry and policy_engine (the default world for this executor).
+        """
         tool_name = audit_entry["tool"]
         tainted = audit_entry["taint"]
 
-        _, capability, side_effect_type, hash_ok = self._tool_context(tool_name)
+        entry_world_id = audit_entry.get("world_id")
+        if self.world_controller is not None and entry_world_id:
+            # Replay with the world that was active when the entry was recorded.
+            try:
+                _registry, _policy_engine, _ = self._build_components_for_world(entry_world_id)
+            except Exception:
+                _registry, _policy_engine = self.registry, self.policy_engine
+        else:
+            # No world_id in entry (old format) — fall back to default (stored) world.
+            _registry, _policy_engine = self.registry, self.policy_engine
 
-        policy = self.policy_engine.decide(
+        _, capability, side_effect_type, hash_ok = self._tool_context(tool_name, _registry)
+
+        policy = _policy_engine.decide(
             tool_name=tool_name,
             capability=capability,
             taint=tainted,
@@ -380,13 +473,28 @@ class Executor:
             "matches": matches,
         }
 
-    def record_absence(
-        self,
-        tool_name: str,
-        rule: str,
-        source_channel: str,
-        taint: bool = False,
-    ) -> None:
+    def _build_components_for_world(self, world_id: str) -> Tuple[ToolRegistry, "PolicyEngine", str]:
+        """Compile a specific world and return its registry + policy engine.
+
+        Used by replay() to re-evaluate a recorded entry against the world
+        that was active at the time it was written.
+        """
+        from safe_mcp_proxy.compiler import compile_world_manifest, resolve_manifest_path
+        assert self._base_dir is not None
+        path = resolve_manifest_path(self._base_dir, world_id or None)
+        world = compile_world_manifest(str(path))
+        registry = ToolRegistry.with_mock_tools(
+            allowlist=world.get("allowlist", []),
+            capability_defs=world.get("capability_definitions"),
+        )
+        policy_engine = self._build_policy_for_world(world)
+        return registry, policy_engine, world.get("world_id", world_id)  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Audit helpers
+    # ------------------------------------------------------------------
+
+    def record_absence(self, tool_name: str, rule: str, source_channel: str, taint: bool = False) -> None:
         """Log an ABSENT decision to the audit trail without executing anything."""
         self._audit(
             tool=tool_name,
@@ -397,13 +505,7 @@ class Executor:
             source_channel=source_channel,
         )
 
-    def record_denial(
-        self,
-        tool_name: str,
-        rule: str,
-        source_channel: str,
-        taint: bool = False,
-    ) -> None:
+    def record_denial(self, tool_name: str, rule: str, source_channel: str, taint: bool = False) -> None:
         """Log a DENY decision to the audit trail without executing anything."""
         self._audit(
             tool=tool_name,
@@ -414,13 +516,7 @@ class Executor:
             source_channel=source_channel,
         )
 
-    def record_simulation(
-        self,
-        tool_name: str,
-        rule: str,
-        source_channel: str,
-        taint: bool = False,
-    ) -> None:
+    def record_simulation(self, tool_name: str, rule: str, source_channel: str, taint: bool = False) -> None:
         """Log a SIMULATE decision to the audit trail without executing anything."""
         self._audit(
             tool=tool_name,
@@ -452,6 +548,10 @@ class Executor:
             "descriptor_hash": descriptor_hash,
             "source_channel": source_channel,
         }
+        # Always record world_id; callers may pass it explicitly via extra,
+        # otherwise fall back to the property (which reads from WorldController).
+        if "world_id" not in extra:
+            extra["world_id"] = self.world_id
         entry.update(extra)
         with self.audit_log_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(entry, sort_keys=True) + "\n")

--- a/safe_mcp_proxy/main.py
+++ b/safe_mcp_proxy/main.py
@@ -7,35 +7,20 @@ from typing import Optional, Union
 import yaml
 
 from safe_mcp_proxy.approval_store import ApprovalStore
-from safe_mcp_proxy.compiler import compile_world_manifest
+from safe_mcp_proxy.compiler import compile_world_manifest, resolve_manifest_path
 from safe_mcp_proxy.execution_mode import ExecutionMode
 from safe_mcp_proxy.executor import Executor
 from safe_mcp_proxy.opa_engine import OPAPolicyEngine
 from safe_mcp_proxy.policy_engine import PolicyEngine
 from safe_mcp_proxy.provenance import Provenance
 from safe_mcp_proxy.registry import ToolRegistry
+from safe_mcp_proxy.world_controller import WorldController
 
 
 def _load_simulation_flag(policy_path: Path) -> bool:
     with policy_path.open("r", encoding="utf-8") as handle:
         cfg = yaml.safe_load(handle) or {}
     return bool(cfg.get("simulation", {}).get("external_side_effects", False))
-
-
-def _resolve_manifest_path(base_dir: Path, world_id: Optional[str]) -> Path:
-    if world_id is None:
-        return base_dir / "world_manifest.yaml"
-
-    candidates = [
-        base_dir / "safe_mcp_proxy" / "config" / "worlds" / f"{world_id}.yaml",
-        base_dir / "worlds" / f"{world_id}.yaml",
-    ]
-    for manifest_path in candidates:
-        if manifest_path.exists():
-            return manifest_path
-
-    searched = ", ".join(str(path) for path in candidates)
-    raise FileNotFoundError(f"World manifest not found for world_id={world_id!r}. Searched: {searched}")
 
 
 def _build_policy_engine(
@@ -64,14 +49,20 @@ def build_executor(
     world_id: Optional[str] = None,
     engine: Optional[str] = None,
 ) -> Executor:
-    manifest_path = _resolve_manifest_path(base_dir, world_id)
+    # Build WorldController as the live world pointer.
+    controller = WorldController(initial_world_id=world_id or "", base_dir=base_dir)
+
+    # Also compile once to derive policy_version and the engine override.
+    manifest_path = resolve_manifest_path(base_dir, world_id)
     manifest_tables = compile_world_manifest(str(manifest_path))
     policy_version = hashlib.sha256(manifest_path.read_bytes()).hexdigest()[:8]
+
+    # Bootstrap registry/policy from the initial world so the Executor can
+    # function even if world_controller is bypassed (e.g. tests, replay fallback).
     registry = ToolRegistry.with_mock_tools(
         allowlist=manifest_tables["allowlist"],
         capability_defs=manifest_tables.get("capability_definitions"),
     )
-    # CLI --engine flag overrides the manifest's policy_engine key; default is "python"
     resolved_engine = engine if engine is not None else manifest_tables.get("policy_engine", "python")
     policy_engine = _build_policy_engine(manifest_tables, resolved_engine, base_dir)
     simulate_external = _load_simulation_flag(base_dir / "safe_mcp_proxy" / "config" / "policy.yaml")
@@ -83,6 +74,8 @@ def build_executor(
         approval_store=ApprovalStore(),
         world_id=manifest_tables.get("world_id", ""),
         policy_version=policy_version,
+        world_controller=controller,
+        base_dir=base_dir,
     )
 
 

--- a/safe_mcp_proxy/world_controller.py
+++ b/safe_mcp_proxy/world_controller.py
@@ -1,0 +1,99 @@
+"""Thread-safe mutable pointer to the currently active world.
+
+WorldController is a singleton owned by build_executor() / the API layer.
+All reads and writes go through an RLock so a world switch is atomic
+relative to in-flight tool calls that read .world.
+"""
+
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from safe_mcp_proxy.compiler import compile_world_manifest, resolve_manifest_path
+
+
+class WorldNotFoundError(FileNotFoundError):
+    """Raised when a requested world_id has no matching manifest file."""
+
+
+class WorldController:
+    def __init__(self, initial_world_id: str, base_dir: Path):
+        self._base_dir = base_dir
+        self._lock = threading.RLock()
+        self._history: List[str] = []
+        self._world_id = initial_world_id
+        self._world = self._compile(initial_world_id)
+        self._history.append(initial_world_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _compile(self, world_id: str) -> Dict[str, Any]:
+        try:
+            path = resolve_manifest_path(self._base_dir, world_id or None)
+            return compile_world_manifest(str(path))
+        except FileNotFoundError as exc:
+            raise WorldNotFoundError(str(exc)) from exc
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def world(self) -> Dict[str, Any]:
+        """Return the current compiled world config (RLock-protected)."""
+        with self._lock:
+            return self._world
+
+    def switch(self, world_id: str, reason: str = "") -> Dict[str, Any]:
+        """Atomically replace the active world and return a diff dict.
+
+        Keys: from, to, appeared (list), vanished (list), reason.
+        Raises WorldNotFoundError if world_id has no manifest.
+        """
+        new_world = self._compile(world_id)  # compile outside lock (I/O can be slow)
+        with self._lock:
+            old_id = self._world_id
+            old_allowlist = set(self._world.get("allowlist", []))
+            new_allowlist = set(new_world.get("allowlist", []))
+            self._world = new_world
+            self._world_id = world_id
+            self._history.append(world_id)
+
+        appeared = sorted(new_allowlist - old_allowlist)
+        vanished = sorted(old_allowlist - new_allowlist)
+        return {
+            "from": old_id,
+            "to": world_id,
+            "appeared": appeared,
+            "vanished": vanished,
+            "reason": reason,
+        }
+
+    def current_id(self) -> str:
+        with self._lock:
+            return self._world_id
+
+    @property
+    def history(self) -> List[str]:
+        with self._lock:
+            return list(self._history)
+
+    def list_tools(self) -> List[Dict[str, Any]]:
+        """Return exposed tools for the current world as plain dicts."""
+        from safe_mcp_proxy.registry import ToolRegistry  # lazy to avoid import cycle
+
+        world = self.world
+        registry = ToolRegistry.with_mock_tools(
+            allowlist=world.get("allowlist", []),
+            capability_defs=world.get("capability_definitions"),
+        )
+        return [
+            {
+                "name": t.name,
+                "capability": t.capability,
+                "side_effect_type": t.side_effect_type,
+            }
+            for t in registry.list_exposed()
+        ]

--- a/tests/test_world_controller.py
+++ b/tests/test_world_controller.py
@@ -1,0 +1,334 @@
+"""Tests for WorldController: thread safety, switch diffs, tool visibility, API integration."""
+
+import asyncio
+import json
+import shutil
+import tempfile
+import textwrap
+import threading
+import unittest
+from pathlib import Path
+
+from safe_mcp_proxy.executor import Executor
+from safe_mcp_proxy.policy_engine import PolicyEngine
+from safe_mcp_proxy.registry import ToolRegistry
+from safe_mcp_proxy.world_controller import WorldController, WorldNotFoundError
+
+try:
+    import fastapi  # noqa: F401
+    import httpx    # noqa: F401
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    _FASTAPI_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers
+# ---------------------------------------------------------------------------
+
+def _make_tmp() -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    # Default world manifest
+    (tmp / "world_manifest.yaml").write_text(textwrap.dedent("""\
+        world_id: default
+        allowed_tools: [read_file, list_repo, send_email]
+        capabilities:
+          read_file: {allowed: true}
+          list_repo: {allowed: true}
+          send_email: {allowed: true}
+          dangerous_exec: {allowed: false}
+        taint_rules: []
+        side_effects: {external: restricted}
+    """), encoding="utf-8")
+    # read_only world
+    worlds_dir = tmp / "worlds"
+    worlds_dir.mkdir()
+    (worlds_dir / "read_only.yaml").write_text(textwrap.dedent("""\
+        world_id: read_only
+        allowed_tools: [read_file]
+        capabilities:
+          read_file: {allowed: true}
+          list_repo: {allowed: false}
+          send_email: {allowed: false}
+          dangerous_exec: {allowed: false}
+        taint_rules: []
+        side_effects: {external: restricted}
+    """), encoding="utf-8")
+    # Stub policy.yaml (needed by build_executor's _load_simulation_flag)
+    config_dir = tmp / "safe_mcp_proxy" / "config"
+    config_dir.mkdir(parents=True)
+    (config_dir / "policy.yaml").write_text("simulation:\n  external_side_effects: true\n")
+    # Stub logs dir
+    (tmp / "safe_mcp_proxy" / "logs").mkdir(parents=True)
+    return tmp
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for WorldController
+# ---------------------------------------------------------------------------
+
+class TestWorldControllerSwitch(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp()
+        self.controller = WorldController(initial_world_id="", base_dir=self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_switch_returns_correct_diff(self):
+        diff = self.controller.switch("read_only")
+        self.assertEqual(diff["from"], "")
+        self.assertEqual(diff["to"], "read_only")
+        self.assertIn("list_repo", diff["vanished"])
+        self.assertIn("send_email", diff["vanished"])
+        self.assertNotIn("read_file", diff["vanished"])
+        self.assertNotIn("read_file", diff["appeared"])
+
+    def test_switch_reason_preserved(self):
+        diff = self.controller.switch("read_only", reason="testing")
+        self.assertEqual(diff["reason"], "testing")
+
+    def test_history_records_switch_order(self):
+        self.controller.switch("read_only")
+        self.controller.switch("")
+        history = self.controller.history
+        self.assertEqual(history[0], "")       # initial
+        self.assertEqual(history[1], "read_only")
+        self.assertEqual(history[2], "")
+
+    def test_current_id_reflects_latest_switch(self):
+        self.assertEqual(self.controller.current_id(), "")
+        self.controller.switch("read_only")
+        self.assertEqual(self.controller.current_id(), "read_only")
+
+    def test_world_not_found_error_for_missing_world(self):
+        with self.assertRaises(WorldNotFoundError):
+            self.controller.switch("nonexistent_world_xyz")
+
+    def test_world_not_found_does_not_corrupt_state(self):
+        try:
+            self.controller.switch("nonexistent_world_xyz")
+        except WorldNotFoundError:
+            pass
+        # Current world unchanged
+        self.assertEqual(self.controller.current_id(), "")
+        self.assertIn("send_email", {t["name"] for t in self.controller.list_tools()})
+
+
+class TestWorldControllerListTools(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_list_tools_reflects_new_world_immediately(self):
+        controller = WorldController(initial_world_id="", base_dir=self.tmp)
+        default_tools = {t["name"] for t in controller.list_tools()}
+        self.assertIn("send_email", default_tools)
+        self.assertIn("list_repo", default_tools)
+
+        controller.switch("read_only")
+
+        readonly_tools = {t["name"] for t in controller.list_tools()}
+        self.assertIn("read_file", readonly_tools)
+        self.assertNotIn("send_email", readonly_tools)
+        self.assertNotIn("list_repo", readonly_tools)
+        self.assertGreater(len(default_tools), len(readonly_tools))
+
+    def test_list_tools_returns_required_keys(self):
+        controller = WorldController(initial_world_id="", base_dir=self.tmp)
+        for tool in controller.list_tools():
+            self.assertIn("name", tool)
+            self.assertIn("capability", tool)
+            self.assertIn("side_effect_type", tool)
+
+
+class TestWorldControllerConcurrency(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_concurrent_switch_and_read_do_not_race(self):
+        controller = WorldController(initial_world_id="", base_dir=self.tmp)
+        errors: list = []
+        n_readers = 2
+        barrier = threading.Barrier(n_readers + 1)  # readers + 1 switcher
+
+        def reader():
+            barrier.wait()
+            for _ in range(100):
+                try:
+                    _ = controller.world
+                    _ = controller.current_id()
+                except Exception as exc:
+                    errors.append(exc)
+
+        def switcher():
+            barrier.wait()
+            for _ in range(20):
+                try:
+                    controller.switch("read_only")
+                    controller.switch("")
+                except WorldNotFoundError as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(n_readers)]
+        threads.append(threading.Thread(target=switcher))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertFalse(errors, f"Concurrency errors: {errors}")
+
+
+# ---------------------------------------------------------------------------
+# replay() fallback for entries without world_id
+# ---------------------------------------------------------------------------
+
+class TestReplayWorldIdFallback(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp()
+        self.audit_file = self.tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+        registry = ToolRegistry.with_mock_tools(
+            allowlist=["read_file"],
+        )
+        policy = PolicyEngine(
+            allowlist=["read_file"],
+            capability_map={"read_file": True},
+            approval_required=[],
+        )
+        self.executor = Executor(
+            registry=registry,
+            policy_engine=policy,
+            audit_log_path=str(self.audit_file),
+            simulate_external=True,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_replay_without_world_id_does_not_raise(self):
+        entry = {
+            "tool": "read_file",
+            "taint": False,
+            "decision": "ALLOW",
+            "rule": "default_allow",
+            # no "world_id" key — simulates old seed entries
+        }
+        result = self.executor.replay(entry)
+        self.assertIn("matches", result)
+        self.assertIn("replayed_decision", result)
+
+    def test_replay_with_world_id_present_does_not_raise(self):
+        entry = {
+            "tool": "read_file",
+            "taint": False,
+            "decision": "ALLOW",
+            "rule": "default_allow",
+            "world_id": "default",
+        }
+        result = self.executor.replay(entry)
+        self.assertIn("matches", result)
+
+
+# ---------------------------------------------------------------------------
+# audit.jsonl contains WORLD_SWITCH event after API call
+# ---------------------------------------------------------------------------
+
+@unittest.skipUnless(_FASTAPI_AVAILABLE, "fastapi/httpx not installed")
+class TestWorldSwitchAPIEndpoints(unittest.TestCase):
+    def setUp(self):
+        from api.main import create_app
+
+        self.tmp = _make_tmp()
+        self.audit_log = self.tmp / "safe_mcp_proxy" / "logs" / "audit.jsonl"
+        self.audit_log.touch()
+
+        # Add read_only world via safe_mcp_proxy/config/worlds/ so build_executor finds it
+        config_worlds = self.tmp / "safe_mcp_proxy" / "config" / "worlds"
+        config_worlds.mkdir(parents=True, exist_ok=True)
+        (config_worlds / "read_only.yaml").write_text(textwrap.dedent("""\
+            world_id: read_only
+            allowed_tools: [read_file]
+            capabilities:
+              read_file: {allowed: true}
+              list_repo: {allowed: false}
+              send_email: {allowed: false}
+              dangerous_exec: {allowed: false}
+            taint_rules: []
+            side_effects: {external: restricted}
+        """), encoding="utf-8")
+
+        self.app = create_app(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _request(self, method: str, path: str, **kwargs):
+        import httpx
+        async def _run():
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+                return await client.request(method, path, **kwargs)
+        return asyncio.run(_run())
+
+    def test_post_world_switch_returns_diff(self):
+        resp = self._request("POST", "/world/switch", params={"world_id": "read_only"})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["to"], "read_only")
+        self.assertIn("appeared", body)
+        self.assertIn("vanished", body)
+
+    def test_post_world_switch_unknown_returns_404(self):
+        resp = self._request("POST", "/world/switch", params={"world_id": "no_such_world"})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_world_current_reflects_switch(self):
+        self._request("POST", "/world/switch", params={"world_id": "read_only"})
+        resp = self._request("GET", "/world/current")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["world_id"], "read_only")
+        self.assertIn("history", body)
+        self.assertIn("read_only", body["history"])
+
+    def test_world_switch_appends_audit_event(self):
+        self._request("POST", "/world/switch", params={"world_id": "read_only", "reason": "test"})
+        lines = [l for l in self.audit_log.read_text().splitlines() if l.strip()]
+        events = [json.loads(l) for l in lines]
+        switch_events = [e for e in events if e.get("event") == "WORLD_SWITCH"]
+        self.assertEqual(len(switch_events), 1)
+        evt = switch_events[0]
+        self.assertIn("diff", evt)
+        self.assertIn("timestamp", evt)
+        self.assertEqual(evt["diff"]["to"], "read_only")
+
+    def test_worlds_current_reflects_switch(self):
+        """Existing /worlds/current endpoint still returns correct tools after switch."""
+        self._request("POST", "/world/switch", params={"world_id": "read_only"})
+        resp = self._request("GET", "/worlds/current")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        tool_names = {t["name"] for t in body["tools"]}
+        self.assertIn("read_file", tool_names)
+        self.assertNotIn("send_email", tool_names)
+
+    def test_execute_reflects_switched_world(self):
+        """After switching to read_only, send_email should be ABSENT."""
+        from safe_mcp_proxy.main import build_executor
+        from safe_mcp_proxy.provenance import Provenance
+
+        executor = build_executor(self.tmp)
+        executor.world_controller.switch("read_only")  # type: ignore[union-attr]
+        prov = Provenance.from_source("cli")
+        result = executor.execute("send_email", {}, prov)
+        self.assertEqual(result["decision"], "ABSENT")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds runtime world switching without proxy restart. The active world
is now a mutable, thread-safe pointer owned by WorldController, wired
through build_executor() into every per-call policy evaluation.

Changes:
- compiler.py: extract resolve_manifest_path() as a public function
  shared by main.py, WorldController, and Executor._build_components_for_world()
- world_controller.py (new): WorldController with RLock-protected .world
  property, .switch() returning appeared/vanished diff, .history, and
  .list_tools() for the current world surface; WorldNotFoundError on
  missing manifest
- executor.py: add optional world_controller + base_dir params; add
  world_id property (reads from WorldController when present);
  _resolve_components() uses stored registry for descriptor-drift
  fidelity but rebuilds PolicyEngine from current world on every call;
  get_any_tool() fallback for tools added by a world switch; every
  _audit() call now includes world_id; replay() falls back to default
  world for entries that predate world_id recording
- main.py: build_executor() creates and wires WorldController as
  singleton; retains bootstrap registry/policy for backward-compat
- api/main.py: expose WorldController on app.state; POST /world/switch
  (returns diff, appends WORLD_SWITCH event to audit.jsonl); GET
  /world/current (returns world_id + history); /worlds/current reads
  live tool surface from WorldController when available
- tests/test_world_controller.py (new): switch diff, history, thread
  safety (Barrier), WorldNotFoundError, list_tools reflection, replay
  fallback without world_id, API endpoint tests (skipped when fastapi
  unavailable)

Atlassian integration untouched.

https://claude.ai/code/session_01EL8ZoQ2vErf3zkbyH6cNAj