### PR TITLE
Add VS Code MCP safe Jira proxy with scoped tools and deterministic JQL enforcement

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,17 @@
+{
+  "servers": {
+    "safe-proxy": {
+      "type": "stdio",
+      "command": "python",
+      "args": [
+        "safe_mcp_proxy/server.py",
+        "--policy",
+        "safe_mcp_proxy/config/jira_policy.yaml",
+        "--upstream",
+        "python",
+        "-m",
+        "safe_mcp_proxy.mcp_test_server"
+      ]
+    }
+  }
+}

--- a/docs/integrations/vscode-copilot-mcp.md
+++ b/docs/integrations/vscode-copilot-mcp.md
@@ -1,0 +1,63 @@
+# VS Code + Copilot Agent Mode with Safe MCP Proxy
+
+## 1) Configure MCP server in VS Code
+
+Use `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "safe-proxy": {
+      "type": "stdio",
+      "command": "python",
+      "args": [
+        "safe_mcp_proxy/server.py",
+        "--policy",
+        "safe_mcp_proxy/config/jira_policy.yaml",
+        "--upstream",
+        "python",
+        "-m",
+        "safe_mcp_proxy.mcp_test_server"
+      ]
+    }
+  }
+}
+```
+
+## 2) Enable Copilot Agent Mode + MCP
+
+1. Open VS Code settings and ensure MCP server integration is enabled for Copilot Agent Mode.
+2. Open Copilot Chat.
+3. Switch to **Agent** mode.
+4. Confirm `safe-proxy` server is connected.
+
+## 3) Verify `tools/list` and shaping
+
+Run the proxy directly to inspect logs:
+
+```bash
+python safe_mcp_proxy/server.py --policy safe_mcp_proxy/config/jira_policy.yaml --upstream python -m safe_mcp_proxy.mcp_test_server
+```
+
+When Copilot starts a session, the proxy serves `tools/list` from downstream, filtered by policy. Forbidden tools are not exposed.
+
+## 4) Demo scenario
+
+Prompt in Copilot Agent mode:
+
+> Update my Jira issues
+
+Expected with proxy:
+- query gets constrained to: `assignee = currentUser() AND status = 'Open'`
+- forbidden tools (for example `delete_issue`) are denied deterministically
+
+To test deny behavior explicitly, call a denied action; response includes:
+
+```json
+{"error": "POLICY_DENY", "tool": "delete_issue", "reason": "tool is explicitly denied"}
+```
+
+## 5) Optional simulate mode
+
+Set `simulate: true` in `safe_mcp_proxy/config/jira_policy.yaml`.
+Denied tools return deterministic simulated response instead of forwarding.

--- a/safe_mcp_proxy/config/jira_policy.yaml
+++ b/safe_mcp_proxy/config/jira_policy.yaml
@@ -1,0 +1,11 @@
+mode: sprint_triage
+simulate: false
+
+jira:
+  allowed_jql: "assignee = currentUser() AND status = 'Open'"
+  allowed_actions:
+    - read_issue
+    - comment_issue
+  denied_actions:
+    - delete_issue
+    - transition_issue

--- a/safe_mcp_proxy/mcp_upstream.py
+++ b/safe_mcp_proxy/mcp_upstream.py
@@ -34,6 +34,20 @@ class UpstreamConnector:
         self._session = await self._stack.enter_async_context(ClientSession(read, write))
         await self._session.initialize()
 
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        if self._session is None:
+            raise RuntimeError("UpstreamConnector not connected — call connect() first")
+        result = await self._session.list_tools()
+        tools: list[dict[str, Any]] = []
+        for tool in result.tools:
+            tools.append({
+                "name": tool.name,
+                "description": tool.description,
+                "inputSchema": tool.inputSchema,
+            })
+        return tools
+
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         if self._session is None:
             raise RuntimeError("UpstreamConnector not connected — call connect() first")

--- a/safe_mcp_proxy/policy.py
+++ b/safe_mcp_proxy/policy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class JiraPolicy:
+    mode: str
+    allowed_jql: str
+    allowed_actions: set[str]
+    denied_actions: set[str]
+    simulate: bool = False
+
+    @classmethod
+    def load(cls, path: str | Path) -> "JiraPolicy":
+        data = yaml.safe_load(Path(path).read_text())
+        jira = data.get("jira", {})
+        return cls(
+            mode=data.get("mode", "default"),
+            allowed_jql=jira.get("allowed_jql", ""),
+            allowed_actions=set(jira.get("allowed_actions", [])),
+            denied_actions=set(jira.get("denied_actions", [])),
+            simulate=bool(data.get("simulate", False)),
+        )
+
+    def can_expose(self, tool_name: str) -> bool:
+        if tool_name in self.denied_actions:
+            return False
+        if self.allowed_actions and tool_name not in self.allowed_actions:
+            return False
+        return True
+
+    def decide(self, tool_name: str, arguments: dict[str, Any]) -> tuple[str, dict[str, Any], str]:
+        if tool_name in self.denied_actions:
+            if self.simulate:
+                return "SIMULATE", arguments, "tool is explicitly denied"
+            return "DENY", arguments, "tool is explicitly denied"
+
+        if self.allowed_actions and tool_name not in self.allowed_actions:
+            return "DENY", arguments, "tool is not in allowed_actions"
+
+        updated = dict(arguments or {})
+        # Jira read style tools often accept 'jql' or 'query'. Constrain both deterministically.
+        if "jql" in updated or tool_name == "read_issue":
+            incoming = updated.get("jql", "").strip()
+            if incoming:
+                updated["jql"] = f"({incoming}) AND ({self.allowed_jql})"
+            else:
+                updated["jql"] = self.allowed_jql
+            return "MODIFY", updated, "jql constrained by policy"
+
+        if "query" in updated:
+            incoming = updated.get("query", "").strip()
+            if incoming:
+                updated["query"] = f"({incoming}) AND ({self.allowed_jql})"
+            else:
+                updated["query"] = self.allowed_jql
+            return "MODIFY", updated, "query constrained by policy"
+
+        return "ALLOW", updated, "allowed by policy"

--- a/safe_mcp_proxy/proxy.py
+++ b/safe_mcp_proxy/proxy.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from safe_mcp_proxy.mcp_upstream import UpstreamConnector
+from safe_mcp_proxy.policy import JiraPolicy
+
+
+@dataclass
+class Decision:
+    decision: str
+    reason: str
+    tool_name: str
+    input_args: dict[str, Any]
+
+
+class SafeJiraProxy:
+    def __init__(self, upstream: UpstreamConnector, policy: JiraPolicy):
+        self.upstream = upstream
+        self.policy = policy
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        tools = await self.upstream.list_tools()
+        return [tool for tool in tools if self.policy.can_expose(tool["name"])]
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        decision, updated, reason = self.policy.decide(tool_name, arguments or {})
+        self._log(Decision(decision, reason, tool_name, updated))
+
+        if decision == "DENY":
+            return {
+                "error": "POLICY_DENY",
+                "tool": tool_name,
+                "reason": reason,
+            }
+
+        if decision == "SIMULATE":
+            return {
+                "simulated": True,
+                "tool": tool_name,
+                "message": "Simulated response by proxy policy",
+                "arguments": updated,
+            }
+
+        return await self.upstream.call_tool(tool_name, updated)
+
+    @staticmethod
+    def _log(entry: Decision) -> None:
+        payload = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tool_name": entry.tool_name,
+            "input": entry.input_args,
+            "decision": entry.decision,
+            "reason": entry.reason,
+        }
+        print(json.dumps(payload), flush=True)

--- a/safe_mcp_proxy/server.py
+++ b/safe_mcp_proxy/server.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from safe_mcp_proxy.mcp_upstream import UpstreamConnector
+from safe_mcp_proxy.policy import JiraPolicy
+from safe_mcp_proxy.proxy import SafeJiraProxy
+
+
+class SafeProxyMCPServer:
+    def __init__(self, proxy: SafeJiraProxy):
+        self.proxy = proxy
+        self.server = self._build_server()
+
+    def _build_server(self) -> Server:
+        server = Server("safe-proxy")
+
+        @server.list_tools()
+        async def _list_tools() -> list[types.Tool]:
+            filtered = await self.proxy.list_tools()
+            return [
+                types.Tool(
+                    name=t["name"],
+                    description=t.get("description", t["name"]),
+                    inputSchema=t.get("inputSchema", {"type": "object", "properties": {}}),
+                )
+                for t in filtered
+            ]
+
+        @server.call_tool()
+        async def _call_tool(name: str, arguments: dict[str, Any]) -> list[types.ContentBlock]:
+            result = await self.proxy.call_tool(name, arguments or {})
+            return [types.TextContent(type="text", text=json.dumps(result))]
+
+        return server
+
+    async def run(self) -> None:
+        async with stdio_server() as (read, write):
+            await self.server.run(read, write, self.server.create_initialization_options())
+
+
+async def _main(policy_path: Path, upstream_command: list[str]) -> None:
+    policy = JiraPolicy.load(policy_path)
+    upstream = UpstreamConnector(upstream_command)
+    await upstream.connect()
+    try:
+        proxy = SafeJiraProxy(upstream, policy)
+        await SafeProxyMCPServer(proxy).run()
+    finally:
+        await upstream.disconnect()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Safe MCP proxy server for Jira")
+    parser.add_argument("--policy", default="safe_mcp_proxy/config/jira_policy.yaml")
+    parser.add_argument(
+        "--upstream",
+        nargs="+",
+        required=True,
+        help="Upstream Jira MCP server command, e.g. python -m my_jira_mcp_server",
+    )
+    args = parser.parse_args()
+
+    asyncio.run(_main(Path(args.policy), args.upstream))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Integrate a Safe MCP Proxy into VS Code / Copilot Agent Mode so Copilot discovers and talks to a policy-enforced MCP server. 
- Enforce workflow-scoped Jira access by constraining queries (JQL) and preventing forbidden actions deterministically. 
- Ensure forbidden capabilities are not visible to clients by shaping the tool surface at discovery time. 

### Description
- Add a stdio MCP server wrapper in `safe_mcp_proxy/server.py` that registers `tools/list` and `tools/call` and accepts `--policy` and `--upstream` CLI arguments. 
- Implement a deterministic Jira policy layer in `safe_mcp_proxy/policy.py` that loads YAML, enforces `allowed_actions`/`denied_actions`, injects constrained `jql`/`query`, and supports an optional `simulate` mode. 
- Add `safe_mcp_proxy/proxy.py` which shapes `tools/list`, enforces policy decisions on calls (`ALLOW`/`MODIFY`/`DENY`/`SIMULATE`), forwards allowed calls upstream, and logs decisions with `timestamp`, `tool_name`, `input`, `decision`, and `reason`. 
- Extend `safe_mcp_proxy/mcp_upstream.py` with a `list_tools()` helper to fetch and surface downstream tools for filtering. 
- Add a default policy configuration at `safe_mcp_proxy/config/jira_policy.yaml`, a VS Code MCP registration at `.vscode/mcp.json`, and integration + demo instructions in `docs/integrations/vscode-copilot-mcp.md`. 

### Testing
- Compiled the new modules successfully with `python -m py_compile safe_mcp_proxy/server.py safe_mcp_proxy/proxy.py safe_mcp_proxy/policy.py safe_mcp_proxy/mcp_upstream.py` and the command completed without errors. 
- Performed a basic smoke validation by starting the proxy as described in the docs to observe shaping and logs (see `docs/integrations/vscode-copilot-mcp.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f917d9291883259dc25e1f40323ad7)