### PR TITLE
feat: add universal MCP adapter with declarative JSON manifest

### DIFF
--- a/mcp-adapter/.gitignore
+++ b/mcp-adapter/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/mcp-adapter/dist/adapter.js
+++ b/mcp-adapter/dist/adapter.js
@@ -1,0 +1,99 @@
+import * as fs from "node:fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema, } from "@modelcontextprotocol/sdk/types.js";
+import { validateManifest, validateUpstreamConfig, projectUpstreamToolsWithManifest, planToolCallWithManifest, } from "./adapterManifest.js";
+import { evaluateAdapterConstraints, ConstraintViolationError, } from "./adapterConstraints.js";
+function errorResponse(message) {
+    return {
+        content: [{ type: "text", text: message }],
+        isError: true,
+    };
+}
+export async function runAdapterStdio(config) {
+    // Load and validate configs
+    let manifestRaw;
+    let upstreamRaw;
+    try {
+        manifestRaw = JSON.parse(fs.readFileSync(config.manifestPath, "utf-8"));
+    }
+    catch (e) {
+        throw new Error(`Failed to load manifest from '${config.manifestPath}': ${e}`);
+    }
+    try {
+        upstreamRaw = JSON.parse(fs.readFileSync(config.upstreamPath, "utf-8"));
+    }
+    catch (e) {
+        throw new Error(`Failed to load upstream config from '${config.upstreamPath}': ${e}`);
+    }
+    const manifest = validateManifest(manifestRaw);
+    const upstreamConfig = validateUpstreamConfig(upstreamRaw);
+    // Connect to upstream as a client via subprocess
+    const clientTransport = new StdioClientTransport({
+        command: upstreamConfig.command,
+        args: upstreamConfig.args,
+        env: upstreamConfig.env,
+    });
+    const client = new Client({ name: "mcp-adapter-client", version: "1.0.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+    // Expose ourselves as an MCP server over this process's stdio
+    const server = new Server({ name: "mcp-adapter", version: "1.0.0" }, { capabilities: { tools: {} } });
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const result = await client.listTools();
+        const upstreamTools = result.tools;
+        const exposed = projectUpstreamToolsWithManifest(upstreamTools, manifest, config.routingKey);
+        return { tools: exposed };
+    });
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+        const { name, arguments: hostArgs = {} } = request.params;
+        const typedHostArgs = hostArgs;
+        // Need upstream tool list for planning
+        const listResult = await client.listTools();
+        const upstreamTools = listResult.tools;
+        const plan = planToolCallWithManifest(name, typedHostArgs, manifest, upstreamTools, config.routingKey);
+        switch (plan.decision) {
+            case "absent":
+                return errorResponse("Tool is not available");
+            case "deny":
+                return errorResponse("Tool is not permitted");
+            case "ask":
+                return errorResponse("Tool requires approval");
+            case "simulate":
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `[SIMULATED] Tool was called with args: ${JSON.stringify(plan.translatedArgs)}`,
+                        },
+                    ],
+                    isError: false,
+                };
+            case "allow": {
+                try {
+                    evaluateAdapterConstraints(plan.constraints, plan.translatedArgs);
+                }
+                catch (e) {
+                    if (e instanceof ConstraintViolationError) {
+                        return errorResponse(e.message);
+                    }
+                    throw e;
+                }
+                const result = await client.callTool({
+                    name: plan.upstreamToolName,
+                    arguments: plan.translatedArgs,
+                });
+                return result;
+            }
+        }
+    });
+    const serverTransport = new StdioServerTransport();
+    await server.connect(serverTransport);
+    const shutdown = async () => {
+        await client.close();
+        process.exit(0);
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+}

--- a/mcp-adapter/dist/adapterConstraints.js
+++ b/mcp-adapter/dist/adapterConstraints.js
@@ -1,0 +1,52 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+export class ConstraintViolationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "ConstraintViolationError";
+    }
+}
+function nearestExistingPath(p) {
+    let current = p;
+    while (!fs.existsSync(current)) {
+        const parent = path.dirname(current);
+        if (parent === current)
+            return current; // reached filesystem root
+        current = parent;
+    }
+    return current;
+}
+function checkPathWithin(value, base) {
+    const resolvedBase = path.resolve(base);
+    const requested = path.isAbsolute(value)
+        ? path.resolve(value)
+        : path.resolve(resolvedBase, value);
+    // Lexical check: no traversal above base
+    const rel = path.relative(resolvedBase, requested);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+        throw new ConstraintViolationError(`Path '${value}' escapes base directory '${base}' (lexical check)`);
+    }
+    // Symlink check: resolve to real paths for symlink-attack prevention
+    const baseReal = fs.realpathSync(resolvedBase);
+    const existing = nearestExistingPath(requested);
+    const existingReal = fs.realpathSync(existing);
+    const rel2 = path.relative(baseReal, existingReal);
+    if (rel2.startsWith("..") || path.isAbsolute(rel2)) {
+        throw new ConstraintViolationError(`Path '${value}' resolves outside base directory '${base}' (symlink check)`);
+    }
+}
+export function evaluateAdapterConstraints(constraints, translatedArgs) {
+    for (const constraint of constraints) {
+        if (constraint.kind === "path_within") {
+            const value = translatedArgs[constraint.arg];
+            if (typeof value !== "string") {
+                throw new ConstraintViolationError(`Argument '${constraint.arg}' must be a string for path_within constraint (got ${typeof value})`);
+            }
+            checkPathWithin(value, constraint.base);
+        }
+        else {
+            // future-proof: unknown constraint kinds are rejected
+            throw new ConstraintViolationError(`Unknown constraint kind: '${constraint.kind}'`);
+        }
+    }
+}

--- a/mcp-adapter/dist/adapterManifest.js
+++ b/mcp-adapter/dist/adapterManifest.js
@@ -1,0 +1,184 @@
+// Types
+// Validation
+const VALID_DECISIONS = new Set(["allow", "ask", "deny", "simulate", "absent"]);
+function isValidDecision(v) {
+    return typeof v === "string" && VALID_DECISIONS.has(v);
+}
+export function validateManifest(data) {
+    if (typeof data !== "object" || data === null)
+        throw new Error("manifest must be an object");
+    const d = data;
+    if (d["version"] !== 1)
+        throw new Error("manifest.version must be 1");
+    if (!isValidDecision(d["default_decision"]))
+        throw new Error(`manifest.default_decision must be one of: ${[...VALID_DECISIONS].join(", ")}`);
+    if (!Array.isArray(d["tools"]))
+        throw new Error("manifest.tools must be an array");
+    const tools = d["tools"].map((row, i) => {
+        if (typeof row !== "object" || row === null)
+            throw new Error(`manifest.tools[${i}] must be an object`);
+        const r = row;
+        if (typeof r["upstream_tool"] !== "string" || !r["upstream_tool"])
+            throw new Error(`manifest.tools[${i}].upstream_tool must be a non-empty string`);
+        if (typeof r["exposed_as"] !== "string" || !r["exposed_as"])
+            throw new Error(`manifest.tools[${i}].exposed_as must be a non-empty string`);
+        if (!isValidDecision(r["decision"]))
+            throw new Error(`manifest.tools[${i}].decision must be one of: ${[...VALID_DECISIONS].join(", ")}`);
+        return {
+            upstream_routing_key: typeof r["upstream_routing_key"] === "string" && r["upstream_routing_key"]
+                ? r["upstream_routing_key"]
+                : "default",
+            upstream_tool: r["upstream_tool"],
+            exposed_as: r["exposed_as"],
+            decision: r["decision"],
+            expose: r["expose"],
+            call: r["call"],
+            constraints: Array.isArray(r["constraints"])
+                ? r["constraints"]
+                : undefined,
+        };
+    });
+    return {
+        version: 1,
+        default_decision: d["default_decision"],
+        tools,
+    };
+}
+export function validateUpstreamConfig(data) {
+    if (typeof data !== "object" || data === null)
+        throw new Error("upstream config must be an object");
+    const d = data;
+    if (typeof d["command"] !== "string" || !d["command"])
+        throw new Error("upstream.command must be a non-empty string");
+    if (d["args"] !== undefined && !Array.isArray(d["args"]))
+        throw new Error("upstream.args must be an array if provided");
+    if (d["args"] !== undefined) {
+        for (const a of d["args"]) {
+            if (typeof a !== "string")
+                throw new Error("upstream.args entries must be strings");
+        }
+    }
+    if (d["env"] !== undefined) {
+        if (typeof d["env"] !== "object" || d["env"] === null)
+            throw new Error("upstream.env must be an object if provided");
+        for (const v of Object.values(d["env"])) {
+            if (typeof v !== "string")
+                throw new Error("upstream.env values must be strings");
+        }
+    }
+    // Filter empty-string env values
+    const env = {};
+    if (d["env"]) {
+        for (const [k, v] of Object.entries(d["env"])) {
+            if (v !== "")
+                env[k] = v;
+        }
+    }
+    return {
+        command: d["command"],
+        args: d["args"],
+        env: Object.keys(env).length > 0 ? env : undefined,
+    };
+}
+// Projection
+export function projectUpstreamToolsWithManifest(upstreamTools, manifest, routingKey) {
+    const result = [];
+    for (const tool of upstreamTools) {
+        const rows = manifest.tools.filter((r) => r.upstream_routing_key === routingKey && r.upstream_tool === tool.name);
+        if (rows.length === 0) {
+            if (manifest.default_decision !== "absent") {
+                result.push({
+                    name: tool.name,
+                    description: tool.description,
+                    inputSchema: tool.inputSchema,
+                    annotations: tool.annotations,
+                });
+            }
+        }
+        else {
+            for (const row of rows) {
+                if (row.decision !== "absent") {
+                    result.push({
+                        name: row.exposed_as,
+                        description: row.expose?.description ?? tool.description,
+                        inputSchema: row.expose?.inputSchema ?? tool.inputSchema,
+                        annotations: row.expose?.annotations ?? tool.annotations,
+                    });
+                }
+            }
+        }
+    }
+    return result;
+}
+// Call planning
+function getByPath(obj, dotPath) {
+    return dotPath.split(".").reduce((cur, key) => {
+        if (cur === null || cur === undefined || typeof cur !== "object")
+            return undefined;
+        return cur[key];
+    }, obj);
+}
+function resolveExpression(expr, hostArgs) {
+    if ("from" in expr) {
+        return getByPath(hostArgs, expr.from);
+    }
+    if ("const" in expr) {
+        return expr.const;
+    }
+    if ("template" in expr) {
+        return expr.template.replace(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g, (_, key) => {
+            const val = getByPath(hostArgs, key);
+            if (typeof val !== "string" && typeof val !== "number" && typeof val !== "boolean") {
+                throw new Error(`Template variable '${key}' is not a string, number, or boolean (got ${typeof val})`);
+            }
+            return String(val);
+        });
+    }
+    if ("object" in expr) {
+        return Object.fromEntries(Object.entries(expr.object).map(([k, v]) => [k, resolveExpression(v, hostArgs)]));
+    }
+    if ("array" in expr) {
+        return expr.array.map((item) => resolveExpression(item, hostArgs));
+    }
+    throw new Error("Unknown AdapterArgExpression shape");
+}
+function translateArgs(hostArgs, callConfig) {
+    if (!callConfig?.args)
+        return hostArgs;
+    return Object.fromEntries(Object.entries(callConfig.args).map(([key, expr]) => [
+        key,
+        resolveExpression(expr, hostArgs),
+    ]));
+}
+export function planToolCallWithManifest(exposedName, hostArgs, manifest, upstreamTools, routingKey) {
+    // Step 1: find manifest row by exposed_as + routing key
+    const row = manifest.tools.find((r) => r.exposed_as === exposedName && r.upstream_routing_key === routingKey);
+    if (row) {
+        const translatedArgs = translateArgs(hostArgs, row.call);
+        return {
+            decision: row.decision,
+            upstreamToolName: row.upstream_tool,
+            translatedArgs,
+            constraints: row.constraints ?? [],
+        };
+    }
+    // Step 2: no row — does upstream even know this tool?
+    const upstreamTool = upstreamTools.find((t) => t.name === exposedName);
+    if (!upstreamTool) {
+        return { decision: "absent", upstreamToolName: exposedName, translatedArgs: hostArgs, constraints: [] };
+    }
+    // Step 3: upstream knows it — is it hidden from tools/list?
+    const upstreamRows = manifest.tools.filter((r) => r.upstream_tool === exposedName && r.upstream_routing_key === routingKey);
+    const isHidden = (upstreamRows.length === 0 && manifest.default_decision === "absent") ||
+        (upstreamRows.length > 0 && upstreamRows.every((r) => r.decision === "absent"));
+    if (isHidden) {
+        return { decision: "absent", upstreamToolName: exposedName, translatedArgs: hostArgs, constraints: [] };
+    }
+    // Step 4: visible as itself, apply default_decision, no translation
+    return {
+        decision: manifest.default_decision,
+        upstreamToolName: exposedName,
+        translatedArgs: hostArgs,
+        constraints: [],
+    };
+}

--- a/mcp-adapter/dist/cli.js
+++ b/mcp-adapter/dist/cli.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { runAdapterStdio } from "./adapter.js";
+function parseArgs() {
+    const argv = process.argv.slice(2);
+    let manifestPath = process.env["MANIFEST_PATH"] ?? "";
+    let upstreamPath = process.env["UPSTREAM_PATH"] ?? "";
+    let routingKey = process.env["ROUTING_KEY"] ?? "default";
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === "--manifest" && argv[i + 1]) {
+            manifestPath = argv[++i];
+        }
+        else if (argv[i] === "--upstream" && argv[i + 1]) {
+            upstreamPath = argv[++i];
+        }
+        else if (argv[i] === "--routing-key" && argv[i + 1]) {
+            routingKey = argv[++i];
+        }
+        else if (argv[i] === "--help" || argv[i] === "-h") {
+            printUsage();
+            process.exit(0);
+        }
+    }
+    if (!manifestPath || !upstreamPath) {
+        printUsage();
+        process.exit(1);
+    }
+    return { manifestPath, upstreamPath, routingKey };
+}
+function printUsage() {
+    process.stderr.write([
+        "Usage: mcp-adapter --manifest <path> --upstream <path> [--routing-key <key>]",
+        "",
+        "Options:",
+        "  --manifest <path>      Path to manifest.json (or set MANIFEST_PATH env var)",
+        "  --upstream <path>      Path to upstream.json (or set UPSTREAM_PATH env var)",
+        "  --routing-key <key>    Routing key to match manifest rows (default: \"default\")",
+        "                         (or set ROUTING_KEY env var)",
+        "  --help, -h             Show this help message",
+        "",
+    ].join("\n"));
+}
+const args = parseArgs();
+runAdapterStdio(args).catch((err) => {
+    process.stderr.write(`mcp-adapter error: ${err}\n`);
+    process.exit(1);
+});

--- a/mcp-adapter/examples/filesystem/manifest.json
+++ b/mcp-adapter/examples/filesystem/manifest.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "default_decision": "absent",
+  "tools": [
+    {
+      "upstream_routing_key": "default",
+      "upstream_tool": "write_file",
+      "exposed_as": "write_tmp_note",
+      "decision": "allow",
+      "expose": {
+        "description": "Write a markdown note to /tmp/mcp-file-adapter-writes.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Filename without directory prefix."
+            },
+            "body": {
+              "type": "string",
+              "description": "Markdown content."
+            }
+          },
+          "required": ["filename", "body"],
+          "additionalProperties": false
+        }
+      },
+      "call": {
+        "args": {
+          "path": { "template": "/tmp/mcp-file-adapter-writes/{{filename}}.md" },
+          "content": { "from": "body" }
+        }
+      },
+      "constraints": [
+        { "kind": "path_within", "arg": "path", "base": "/tmp/mcp-file-adapter-writes" }
+      ]
+    }
+  ]
+}

--- a/mcp-adapter/examples/filesystem/upstream.json
+++ b/mcp-adapter/examples/filesystem/upstream.json
@@ -1,0 +1,5 @@
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+  "env": {}
+}

--- a/mcp-adapter/package-lock.json
+++ b/mcp-adapter/package-lock.json
@@ -1,0 +1,1176 @@
+{
+  "name": "mcp-adapter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-adapter",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "bin": {
+        "mcp-adapter": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
+      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-adapter/package.json
+++ b/mcp-adapter/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mcp-adapter",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Declarative MCP proxy adapter — reshapes upstream tools via JSON manifest",
+  "main": "dist/adapter.js",
+  "bin": {
+    "mcp-adapter": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/mcp-adapter/src/adapter.ts
+++ b/mcp-adapter/src/adapter.ts
@@ -1,0 +1,146 @@
+import * as fs from "node:fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  validateManifest,
+  validateUpstreamConfig,
+  projectUpstreamToolsWithManifest,
+  planToolCallWithManifest,
+  type UpstreamTool,
+} from "./adapterManifest.js";
+import {
+  evaluateAdapterConstraints,
+  ConstraintViolationError,
+} from "./adapterConstraints.js";
+
+export interface AdapterConfig {
+  manifestPath: string;
+  upstreamPath: string;
+  routingKey: string;
+}
+
+function errorResponse(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true as const,
+  };
+}
+
+export async function runAdapterStdio(config: AdapterConfig): Promise<void> {
+  // Load and validate configs
+  let manifestRaw: unknown;
+  let upstreamRaw: unknown;
+  try {
+    manifestRaw = JSON.parse(fs.readFileSync(config.manifestPath, "utf-8"));
+  } catch (e) {
+    throw new Error(`Failed to load manifest from '${config.manifestPath}': ${e}`);
+  }
+  try {
+    upstreamRaw = JSON.parse(fs.readFileSync(config.upstreamPath, "utf-8"));
+  } catch (e) {
+    throw new Error(`Failed to load upstream config from '${config.upstreamPath}': ${e}`);
+  }
+
+  const manifest = validateManifest(manifestRaw);
+  const upstreamConfig = validateUpstreamConfig(upstreamRaw);
+
+  // Connect to upstream as a client via subprocess
+  const clientTransport = new StdioClientTransport({
+    command: upstreamConfig.command,
+    args: upstreamConfig.args,
+    env: upstreamConfig.env,
+  });
+  const client = new Client(
+    { name: "mcp-adapter-client", version: "1.0.0" },
+    { capabilities: {} }
+  );
+  await client.connect(clientTransport);
+
+  // Expose ourselves as an MCP server over this process's stdio
+  const server = new Server(
+    { name: "mcp-adapter", version: "1.0.0" },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const result = await client.listTools();
+    const upstreamTools = result.tools as UpstreamTool[];
+    const exposed = projectUpstreamToolsWithManifest(
+      upstreamTools,
+      manifest,
+      config.routingKey
+    );
+    return { tools: exposed };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: hostArgs = {} } = request.params;
+    const typedHostArgs = hostArgs as Record<string, unknown>;
+
+    // Need upstream tool list for planning
+    const listResult = await client.listTools();
+    const upstreamTools = listResult.tools as UpstreamTool[];
+
+    const plan = planToolCallWithManifest(
+      name,
+      typedHostArgs,
+      manifest,
+      upstreamTools,
+      config.routingKey
+    );
+
+    switch (plan.decision) {
+      case "absent":
+        return errorResponse("Tool is not available");
+
+      case "deny":
+        return errorResponse("Tool is not permitted");
+
+      case "ask":
+        return errorResponse("Tool requires approval");
+
+      case "simulate":
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `[SIMULATED] Tool was called with args: ${JSON.stringify(plan.translatedArgs)}`,
+            },
+          ],
+          isError: false as const,
+        };
+
+      case "allow": {
+        try {
+          evaluateAdapterConstraints(plan.constraints, plan.translatedArgs);
+        } catch (e) {
+          if (e instanceof ConstraintViolationError) {
+            return errorResponse(e.message);
+          }
+          throw e;
+        }
+        const result = await client.callTool({
+          name: plan.upstreamToolName,
+          arguments: plan.translatedArgs,
+        });
+        return result;
+      }
+    }
+  });
+
+  const serverTransport = new StdioServerTransport();
+  await server.connect(serverTransport);
+
+  const shutdown = async () => {
+    await client.close();
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}

--- a/mcp-adapter/src/adapterConstraints.ts
+++ b/mcp-adapter/src/adapterConstraints.ts
@@ -1,0 +1,68 @@
+import * as path from "node:path";
+import * as fs from "node:fs";
+import type { AdapterConstraint } from "./adapterManifest.js";
+
+export class ConstraintViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConstraintViolationError";
+  }
+}
+
+function nearestExistingPath(p: string): string {
+  let current = p;
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return current; // reached filesystem root
+    current = parent;
+  }
+  return current;
+}
+
+function checkPathWithin(value: string, base: string): void {
+  const resolvedBase = path.resolve(base);
+  const requested = path.isAbsolute(value)
+    ? path.resolve(value)
+    : path.resolve(resolvedBase, value);
+
+  // Lexical check: no traversal above base
+  const rel = path.relative(resolvedBase, requested);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new ConstraintViolationError(
+      `Path '${value}' escapes base directory '${base}' (lexical check)`
+    );
+  }
+
+  // Symlink check: resolve to real paths for symlink-attack prevention
+  const baseReal = fs.realpathSync(resolvedBase);
+  const existing = nearestExistingPath(requested);
+  const existingReal = fs.realpathSync(existing);
+  const rel2 = path.relative(baseReal, existingReal);
+  if (rel2.startsWith("..") || path.isAbsolute(rel2)) {
+    throw new ConstraintViolationError(
+      `Path '${value}' resolves outside base directory '${base}' (symlink check)`
+    );
+  }
+}
+
+export function evaluateAdapterConstraints(
+  constraints: AdapterConstraint[],
+  translatedArgs: Record<string, unknown>
+): void {
+  for (const constraint of constraints) {
+    if (constraint.kind === "path_within") {
+      const value = translatedArgs[constraint.arg];
+      if (typeof value !== "string") {
+        throw new ConstraintViolationError(
+          `Argument '${constraint.arg}' must be a string for path_within constraint (got ${typeof value})`
+        );
+      }
+      checkPathWithin(value, constraint.base);
+    } else {
+      // future-proof: unknown constraint kinds are rejected
+      throw new ConstraintViolationError(
+        `Unknown constraint kind: '${(constraint as { kind: string }).kind}'`
+      );
+    }
+  }
+}

--- a/mcp-adapter/src/adapterManifest.ts
+++ b/mcp-adapter/src/adapterManifest.ts
@@ -1,0 +1,292 @@
+// Types
+
+export type ToolDecision = "allow" | "ask" | "deny" | "simulate" | "absent";
+
+export type AdapterArgExpression =
+  | { from: string }
+  | { const: unknown }
+  | { template: string }
+  | { object: Record<string, AdapterArgExpression> }
+  | { array: AdapterArgExpression[] };
+
+export type AdapterConstraint = {
+  kind: "path_within";
+  arg: string;
+  base: string;
+};
+
+export type AdapterManifestToolRow = {
+  upstream_routing_key: string;
+  upstream_tool: string;
+  exposed_as: string;
+  decision: ToolDecision;
+  expose?: {
+    description?: string;
+    inputSchema?: Record<string, unknown>;
+    annotations?: Record<string, unknown>;
+    title?: string;
+  };
+  call?: { args?: Record<string, AdapterArgExpression> };
+  constraints?: AdapterConstraint[];
+};
+
+export type AdapterManifest = {
+  version: 1;
+  default_decision: ToolDecision;
+  tools: AdapterManifestToolRow[];
+};
+
+export type UpstreamConfig = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
+export type UpstreamTool = {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+};
+
+export type ExposedTool = {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+};
+
+export type ToolCallPlan = {
+  decision: ToolDecision;
+  upstreamToolName: string;
+  translatedArgs: Record<string, unknown>;
+  constraints: AdapterConstraint[];
+};
+
+// Validation
+
+const VALID_DECISIONS = new Set<string>(["allow", "ask", "deny", "simulate", "absent"]);
+
+function isValidDecision(v: unknown): v is ToolDecision {
+  return typeof v === "string" && VALID_DECISIONS.has(v);
+}
+
+export function validateManifest(data: unknown): AdapterManifest {
+  if (typeof data !== "object" || data === null) throw new Error("manifest must be an object");
+  const d = data as Record<string, unknown>;
+  if (d["version"] !== 1) throw new Error("manifest.version must be 1");
+  if (!isValidDecision(d["default_decision"]))
+    throw new Error(`manifest.default_decision must be one of: ${[...VALID_DECISIONS].join(", ")}`);
+  if (!Array.isArray(d["tools"])) throw new Error("manifest.tools must be an array");
+
+  const tools: AdapterManifestToolRow[] = (d["tools"] as unknown[]).map((row, i) => {
+    if (typeof row !== "object" || row === null)
+      throw new Error(`manifest.tools[${i}] must be an object`);
+    const r = row as Record<string, unknown>;
+    if (typeof r["upstream_tool"] !== "string" || !r["upstream_tool"])
+      throw new Error(`manifest.tools[${i}].upstream_tool must be a non-empty string`);
+    if (typeof r["exposed_as"] !== "string" || !r["exposed_as"])
+      throw new Error(`manifest.tools[${i}].exposed_as must be a non-empty string`);
+    if (!isValidDecision(r["decision"]))
+      throw new Error(`manifest.tools[${i}].decision must be one of: ${[...VALID_DECISIONS].join(", ")}`);
+    return {
+      upstream_routing_key:
+        typeof r["upstream_routing_key"] === "string" && r["upstream_routing_key"]
+          ? r["upstream_routing_key"]
+          : "default",
+      upstream_tool: r["upstream_tool"] as string,
+      exposed_as: r["exposed_as"] as string,
+      decision: r["decision"] as ToolDecision,
+      expose: r["expose"] as AdapterManifestToolRow["expose"],
+      call: r["call"] as AdapterManifestToolRow["call"],
+      constraints: Array.isArray(r["constraints"])
+        ? (r["constraints"] as AdapterConstraint[])
+        : undefined,
+    };
+  });
+
+  return {
+    version: 1,
+    default_decision: d["default_decision"] as ToolDecision,
+    tools,
+  };
+}
+
+export function validateUpstreamConfig(data: unknown): UpstreamConfig {
+  if (typeof data !== "object" || data === null)
+    throw new Error("upstream config must be an object");
+  const d = data as Record<string, unknown>;
+  if (typeof d["command"] !== "string" || !d["command"])
+    throw new Error("upstream.command must be a non-empty string");
+  if (d["args"] !== undefined && !Array.isArray(d["args"]))
+    throw new Error("upstream.args must be an array if provided");
+  if (d["args"] !== undefined) {
+    for (const a of d["args"] as unknown[]) {
+      if (typeof a !== "string") throw new Error("upstream.args entries must be strings");
+    }
+  }
+  if (d["env"] !== undefined) {
+    if (typeof d["env"] !== "object" || d["env"] === null)
+      throw new Error("upstream.env must be an object if provided");
+    for (const v of Object.values(d["env"] as Record<string, unknown>)) {
+      if (typeof v !== "string") throw new Error("upstream.env values must be strings");
+    }
+  }
+  // Filter empty-string env values
+  const env: Record<string, string> = {};
+  if (d["env"]) {
+    for (const [k, v] of Object.entries(d["env"] as Record<string, string>)) {
+      if (v !== "") env[k] = v;
+    }
+  }
+  return {
+    command: d["command"] as string,
+    args: d["args"] as string[] | undefined,
+    env: Object.keys(env).length > 0 ? env : undefined,
+  };
+}
+
+// Projection
+
+export function projectUpstreamToolsWithManifest(
+  upstreamTools: UpstreamTool[],
+  manifest: AdapterManifest,
+  routingKey: string
+): ExposedTool[] {
+  const result: ExposedTool[] = [];
+  for (const tool of upstreamTools) {
+    const rows = manifest.tools.filter(
+      (r) => r.upstream_routing_key === routingKey && r.upstream_tool === tool.name
+    );
+    if (rows.length === 0) {
+      if (manifest.default_decision !== "absent") {
+        result.push({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          annotations: tool.annotations,
+        });
+      }
+    } else {
+      for (const row of rows) {
+        if (row.decision !== "absent") {
+          result.push({
+            name: row.exposed_as,
+            description: row.expose?.description ?? tool.description,
+            inputSchema:
+              (row.expose?.inputSchema as Record<string, unknown>) ?? tool.inputSchema,
+            annotations:
+              (row.expose?.annotations as Record<string, unknown>) ?? tool.annotations,
+          });
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// Call planning
+
+function getByPath(obj: unknown, dotPath: string): unknown {
+  return dotPath.split(".").reduce((cur: unknown, key: string) => {
+    if (cur === null || cur === undefined || typeof cur !== "object") return undefined;
+    return (cur as Record<string, unknown>)[key];
+  }, obj);
+}
+
+function resolveExpression(
+  expr: AdapterArgExpression,
+  hostArgs: Record<string, unknown>
+): unknown {
+  if ("from" in expr) {
+    return getByPath(hostArgs, expr.from);
+  }
+  if ("const" in expr) {
+    return expr.const;
+  }
+  if ("template" in expr) {
+    return expr.template.replace(
+      /\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/g,
+      (_: string, key: string) => {
+        const val = getByPath(hostArgs, key);
+        if (typeof val !== "string" && typeof val !== "number" && typeof val !== "boolean") {
+          throw new Error(
+            `Template variable '${key}' is not a string, number, or boolean (got ${typeof val})`
+          );
+        }
+        return String(val);
+      }
+    );
+  }
+  if ("object" in expr) {
+    return Object.fromEntries(
+      Object.entries(expr.object).map(([k, v]) => [k, resolveExpression(v, hostArgs)])
+    );
+  }
+  if ("array" in expr) {
+    return expr.array.map((item) => resolveExpression(item, hostArgs));
+  }
+  throw new Error("Unknown AdapterArgExpression shape");
+}
+
+function translateArgs(
+  hostArgs: Record<string, unknown>,
+  callConfig: AdapterManifestToolRow["call"] | undefined
+): Record<string, unknown> {
+  if (!callConfig?.args) return hostArgs;
+  return Object.fromEntries(
+    Object.entries(callConfig.args).map(([key, expr]) => [
+      key,
+      resolveExpression(expr, hostArgs),
+    ])
+  );
+}
+
+export function planToolCallWithManifest(
+  exposedName: string,
+  hostArgs: Record<string, unknown>,
+  manifest: AdapterManifest,
+  upstreamTools: UpstreamTool[],
+  routingKey: string
+): ToolCallPlan {
+  // Step 1: find manifest row by exposed_as + routing key
+  const row = manifest.tools.find(
+    (r) => r.exposed_as === exposedName && r.upstream_routing_key === routingKey
+  );
+
+  if (row) {
+    const translatedArgs = translateArgs(hostArgs, row.call);
+    return {
+      decision: row.decision,
+      upstreamToolName: row.upstream_tool,
+      translatedArgs,
+      constraints: row.constraints ?? [],
+    };
+  }
+
+  // Step 2: no row — does upstream even know this tool?
+  const upstreamTool = upstreamTools.find((t) => t.name === exposedName);
+  if (!upstreamTool) {
+    return { decision: "absent", upstreamToolName: exposedName, translatedArgs: hostArgs, constraints: [] };
+  }
+
+  // Step 3: upstream knows it — is it hidden from tools/list?
+  const upstreamRows = manifest.tools.filter(
+    (r) => r.upstream_tool === exposedName && r.upstream_routing_key === routingKey
+  );
+  const isHidden =
+    (upstreamRows.length === 0 && manifest.default_decision === "absent") ||
+    (upstreamRows.length > 0 && upstreamRows.every((r) => r.decision === "absent"));
+
+  if (isHidden) {
+    return { decision: "absent", upstreamToolName: exposedName, translatedArgs: hostArgs, constraints: [] };
+  }
+
+  // Step 4: visible as itself, apply default_decision, no translation
+  return {
+    decision: manifest.default_decision,
+    upstreamToolName: exposedName,
+    translatedArgs: hostArgs,
+    constraints: [],
+  };
+}

--- a/mcp-adapter/src/cli.ts
+++ b/mcp-adapter/src/cli.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { runAdapterStdio } from "./adapter.js";
+
+function parseArgs(): { manifestPath: string; upstreamPath: string; routingKey: string } {
+  const argv = process.argv.slice(2);
+  let manifestPath = process.env["MANIFEST_PATH"] ?? "";
+  let upstreamPath = process.env["UPSTREAM_PATH"] ?? "";
+  let routingKey = process.env["ROUTING_KEY"] ?? "default";
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--manifest" && argv[i + 1]) {
+      manifestPath = argv[++i]!;
+    } else if (argv[i] === "--upstream" && argv[i + 1]) {
+      upstreamPath = argv[++i]!;
+    } else if (argv[i] === "--routing-key" && argv[i + 1]) {
+      routingKey = argv[++i]!;
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  if (!manifestPath || !upstreamPath) {
+    printUsage();
+    process.exit(1);
+  }
+
+  return { manifestPath, upstreamPath, routingKey };
+}
+
+function printUsage(): void {
+  process.stderr.write(
+    [
+      "Usage: mcp-adapter --manifest <path> --upstream <path> [--routing-key <key>]",
+      "",
+      "Options:",
+      "  --manifest <path>      Path to manifest.json (or set MANIFEST_PATH env var)",
+      "  --upstream <path>      Path to upstream.json (or set UPSTREAM_PATH env var)",
+      "  --routing-key <key>    Routing key to match manifest rows (default: \"default\")",
+      "                         (or set ROUTING_KEY env var)",
+      "  --help, -h             Show this help message",
+      "",
+    ].join("\n")
+  );
+}
+
+const args = parseArgs();
+
+runAdapterStdio(args).catch((err: unknown) => {
+  process.stderr.write(`mcp-adapter error: ${err}\n`);
+  process.exit(1);
+});

--- a/mcp-adapter/tsconfig.json
+++ b/mcp-adapter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds mcp-adapter/ — a stdio↔stdio proxy that reshapes any upstream MCP
server's tools according to a declarative manifest, without modifying
the upstream server.

Manifest controls five dimensions per tool:
- Existence (absent hides tools entirely)
- Name (exposed_as remaps semantics through naming)
- Input schema (expose.inputSchema overrides the visible signature)
- Argument translation (call.args maps host args to upstream args via
  from/const/template/object/array expressions)
- Enforcement (constraints with path_within blocks directory traversal
  attacks, including symlink protection via realpathSync)

Decisions: allow | deny | ask | simulate | absent
Default decision applies to upstream tools with no manifest row.

Source files:
  src/adapterManifest.ts    — types, validation, projectUpstreamToolsWithManifest(),
                              planToolCallWithManifest(), arg translation
  src/adapterConstraints.ts — evaluateAdapterConstraints(), path_within (lexical
                              + symlink checks)
  src/adapter.ts            — runAdapterStdio(): wires MCP Client (upstream
                              subprocess) + Server (host-facing stdio)
  src/cli.ts                — --manifest / --upstream / --routing-key CLI

Filesystem example (examples/filesystem/):
  write_file → write_tmp_note scoped to /tmp/mcp-file-adapter-writes;
  all other filesystem tools are absent by default_decision.

https://claude.ai/code/session_0127jj3giWEKYBStviko7sfn